### PR TITLE
Update Keybinds.conf

### DIFF
--- a/config/hypr/configs/Keybinds.conf
+++ b/config/hypr/configs/Keybinds.conf
@@ -36,7 +36,7 @@ $WofiBig = $scriptsDir/WofiBig.sh
 $WofiEmoji = $scriptsDir/WofiEmoji.sh
 
 # see https://wiki.hyprland.org/Configuring/Binds/ for more
-bind = CTRL ALT, Delete, exit
+bind = CTRL ALT, Delete, hyprctl dispatch exit 0
 bind = $mainMod SHIFT, C, exec, hyprctl reload
 bind = $mainMod SHIFT, D, exec, $WofiBig
 bind = $mainMod, D, exec, $Wofi


### PR DESCRIPTION
Fixed an issue where using the 'CTRL + ALT + Del' keybind to exit/logout of Hyprland would result in a black screen (at least on my machine), rather than just using exit I changed it to use the 'hyprctl dispatch exit 0' command