### PR TITLE
Laptop conf file creation and moving specific laptop use cases into into it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGES
 
+### 13-Nov-2023
+- created a separated conf for Laptop (Laptops.conf) in ~/.config/hyp/configs . This was mostly from Keybinds.conf. This is just to easily identity for laptop Keybinds specific.
+
 ### 12-Nov-2023
 - added monitor resolution for better rofi appearance
 <p align="center">

--- a/config/hypr/configs/Keybinds.conf
+++ b/config/hypr/configs/Keybinds.conf
@@ -1,26 +1,18 @@
 # See https://wiki.hyprland.org/Configuring/Keywords/ for more
 # Setting variables
+# See laptops.conf 
+
 $mainMod = SUPER
 $files = thunar
 $browser = firefox
 $term = kitty
-$hyprDir = $HOME/.config/hypr
 $scriptsDir = $HOME/.config/hypr/scripts
 
 # Scripts Variables
 $AirplaneMode = $scriptsDir/AirplaneMode.sh
-$backlight = $scriptsDir/Brightness.sh
-$ChangeBlur = $scriptsDir/ChangeBlur.sh
-$DarkLight = $scriptsDir/DarkLight.sh
-$kbacklight = $scriptsDir/BrightnessKbd.sh
-$LidSwitch = $scriptsDir/LidSwitch.sh
-$LockScreen = $scriptsDir/LockScreen.sh
 $Media = $scriptsDir/MediaCtrl.sh
 $screenshot = $scriptsDir/ScreenShot.sh
-$touchpad = $scriptsDir/TouchPad.sh
 $volume = $scriptsDir/Volume.sh
-$waybar = $scriptsDir/Waybar.sh
-
 
 # see https://wiki.hyprland.org/Configuring/Binds/ for more
 bind = CTRL ALT, Delete, exec, hyprctl dispatch exit 0
@@ -49,9 +41,6 @@ bind = $mainMod, B, exec, killall -SIGUSR1 waybar # Toggle hide/show waybar
 bind = $mainMod SHIFT, G, exec, $scriptsDir/GameMode.sh
 bind = CTRL SHIFT, W, exec, $scriptsDir/Refresh.sh
 
-#bind = $mainMod SHIFT, M, exec, hyprctl dispatch splitratio -0.3
-#bind = $mainMod SHIFT, Y, exec, $term --class clock -T clock -e tty-clock -c -C 7 -r -s -f "%A, %B, %d"
-
 bind = $mainMod CTRL, D, layoutmsg, removemaster
 bind = $mainMod, Escape, exec, hyprctl kill
 bind = $mainMod, I, layoutmsg, addmaster
@@ -62,6 +51,7 @@ bind = $mainMod, P, pseudo, # dwindle
 bind = $mainMod CTRL, Return, layoutmsg, swapwithmaster
 bind = $mainMod, Space, exec, $scriptsDir/ChangeLayout.sh
 bind = $mainMod ALT, V, exec, $scriptsDir/ClipManager.sh
+bind = $mainMod SHIFT, M, exec, hyprctl dispatch splitratio -0.3
 
 # group
 bind = $mainMod, G, togglegroup
@@ -74,15 +64,7 @@ bind = ALT SHIFT, tab, bringactivetotop,   # bring it to the top
 bind = , xf86audioraisevolume, exec, $volume --inc #volume up
 bind = , xf86audiolowervolume, exec, $volume --dec #volume down
 bind = , xf86AudioMicMute, exec, $volume --toggle-mic #mute mic
-bind = , xf86Launch1, exec, rog-control-center # ASUS Armory crate button
 bind = , xf86audiomute, exec, $volume --toggle #FN+F1
-bind = , xf86KbdBrightnessDown, exec, $kbacklight --dec #FN+F2 Keyboard brightness down
-bind = , xf86KbdBrightnessUp, exec, $kbacklight --inc #FN+F3 Keyboard brightnes up
-bind = , xf86Launch3, exec, asusctl led-mode -n #FN+F4 Switch keyboard RGB profile 
-bind = , xf86Launch4, exec, asusctl profile -n  #FN+F5 change of fan profiles (Quite, Balance Performance)
-bind = , xf86MonBrightnessDown, exec, $backlight --dec #FN+F7
-bind = , xf86MonBrightnessUp, exec, $backlight --inc #FN+F8
-bind = , xf86TouchpadToggle, exec, $touchpad #FN+10 disable touchpad
 bind = , xf86Sleep, exec, $LockScreen #FN+F11 (sleep button) 
 bind = , xf86Rfkill, exec, $AirplaneMode #Airplane mode FN+F12
 
@@ -93,13 +75,6 @@ bind = , xf86AudioPlay, exec, $Media --pause
 bind = , xf86AudioNext, exec, $Media --nxt
 bind = , xf86AudioPrev, exec, $Media --prv
 bind = , xf86audiostop, exec, $Media --stop
-
-# triggered when external monitor is connected and closing lid (For Laptop)
-bindl=,switch:Lid Switch, exec, $LidSwitch
-
-# From manual but it does not work
-#bindl = , switch:off:Lid Switch,exec,hyprctl keyword monitor "eDP-1, 2560x1440@165, 0x0, 1"
-#bindl = , switch:on:Lid Switch,exec,hyprctl keyword monitor "eDP-1, disable"
 
 # Resize (vim style)
 binde = $mainMod SHIFT, H, resizeactive,-50 0
@@ -122,7 +97,6 @@ bind = $mainMod CTRL, left, movewindow, l
 bind = $mainMod CTRL, right, movewindow, r
 bind = $mainMod CTRL, up, movewindow, u
 bind = $mainMod CTRL, down, movewindow, d
-
 
 # Move focus with mainMod + arrow keys
 bind = $mainMod, left, movefocus, l
@@ -196,9 +170,4 @@ bind = $mainMod SHIFT, Print, exec, $screenshot --area
 # screenshot with swappy (another screenshot tool)
 bind = $mainMod SHIFT, S, exec, grim -g "$(slurp)" - | swappy -f -
 
-# Screenshot keybindings for Asus G15 (no PrinSrc button)
-bind = $mainMod, F6, exec, $screenshot --now
-bind = $mainMod SHIFT, F6, exec, $screenshot --area
-bind = $mainMod CTRL SHIFT, F6, exec, $screenshot --in5
-bind = $mainMod ALT, F6, exec, $screenshot --in10
 

--- a/config/hypr/configs/Laptops.conf
+++ b/config/hypr/configs/Laptops.conf
@@ -1,0 +1,37 @@
+# See https://wiki.hyprland.org/Configuring/Keywords/ for more
+# Setting variables
+# This configs are mostly for laptops. This is addemdum to Keybinds.conf
+
+$mainMod = SUPER
+$scriptsDir = $HOME/.config/hypr/scripts
+
+# Scripts Variables
+$backlight = $scriptsDir/Brightness.sh
+$kbacklight = $scriptsDir/BrightnessKbd.sh
+$LidSwitch = $scriptsDir/LidSwitch.sh
+
+$screenshot = $scriptsDir/ScreenShot.sh
+$touchpad = $scriptsDir/TouchPad.sh
+
+bind = , xf86KbdBrightnessDown, exec, $kbacklight --dec #FN+F2 Keyboard brightness Down
+bind = , xf86KbdBrightnessUp, exec, $kbacklight --inc #FN+F3 Keyboard brightnes up
+bind = , xf86Launch1, exec, rog-control-center # ASUS Armory crate button
+bind = , xf86Launch3, exec, asusctl led-mode -n #FN+F4 Switch keyboard RGB profile 
+bind = , xf86Launch4, exec, asusctl profile -n  #FN+F5 change of fan profiles (Quite, Balance, Performance)
+bind = , xf86MonBrightnessDown, exec, $backlight --dec #FN+F7
+bind = , xf86MonBrightnessUp, exec, $backlight --inc #FN+F8
+bind = , xf86TouchpadToggle, exec, $touchpad #FN+10 disable touchpad
+
+# triggered when external monitor is connected and closing lid (For Laptop)
+# bindl=,switch:Lid Switch, exec, $LidSwitch 
+# NOTE: (12-Nov-2023) This use to work before but seems below is ok now
+# From WIKI This is to disable laptop monitor when lid is closed.
+# consult https://wiki.hyprland.org/hyprland-wiki/pages/Configuring/Binds/#switches
+bindl = , switch:off:Lid Switch,exec,hyprctl keyword monitor "eDP-1, preferred, auto, 1"
+bindl = , switch:on:Lid Switch,exec,hyprctl keyword monitor "eDP-1, disable"
+
+# Screenshot keybindings for Asus G15 (no PrinSrc button)
+bind = $mainMod, F6, exec, $screenshot --now
+bind = $mainMod SHIFT, F6, exec, $screenshot --area
+bind = $mainMod CTRL SHIFT, F6, exec, $screenshot --in5
+bind = $mainMod ALT, F6, exec, $screenshot --in10

--- a/config/hypr/hyprland.conf
+++ b/config/hypr/hyprland.conf
@@ -4,6 +4,7 @@ $configs = $HOME/.config/hypr/configs
 source=$configs/ENVariables.conf
 source=$configs/Execs.conf
 source=$configs/Keybinds.conf
+source=$configs/Laptops.conf
 source=$configs/Monitors.conf
 source=$configs/WindowRules.conf
 source=$configs/Settings.conf


### PR DESCRIPTION
Most of these functions are from Keybinds.conf to separate a very specific laptop use cases. i.e. Keyboard brightness, Brightness screen, Lid switch etc.

Although can be use for desktop as well, granted your hardware support. ie. Brightness