### PR TITLE
fix(RofiBeats): Remove notification when canceled

### DIFF
--- a/config/hypr/scripts/RofiBeats.sh
+++ b/config/hypr/scripts/RofiBeats.sh
@@ -28,6 +28,10 @@ notification() {
 main() {
   choice=$(printf "%s\n" "${!menu_options[@]}" | rofi -dmenu -config ~/.config/rofi/config-rofi-Beats.rasi -i -p "")
 
+  if [ -z "$choice" ]; then
+    exit 1
+  fi
+
   link="${menu_options[$choice]}"
 
   notification "$choice"


### PR DESCRIPTION
Remove notification and further execution when user selects nothing/closes RofiBeats
