### PR TITLE
Fix: Set cava waybar input to pulse audio

### DIFF
--- a/config/hypr/scripts/WaybarCava.sh
+++ b/config/hypr/scripts/WaybarCava.sh
@@ -21,6 +21,10 @@ cat >"$config_file" <<EOF
 [general]
 bars = 10
 
+[input]
+method = pulse
+source = auto
+
 [output]
 method = raw
 raw_target = /dev/stdout


### PR DESCRIPTION
# Pull Request

## Description

Cava does not always default to pulseaudio. 
Modify Waybar-Cava script to use pulseaudio.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.