### PR TITLE
Used socket for better killing the process

### DIFF
--- a/config/hypr/UserScripts/RofiBeats.sh
+++ b/config/hypr/UserScripts/RofiBeats.sh
@@ -38,11 +38,11 @@ main() {
   
   # Check if the link is a playlist
   if [[ $link == *playlist* ]]; then
-    mpv --shuffle --vid=no "$link"
+    mpv --input-ipc-server=$HOME/.cache/mpvsocket --shuffle --vid=no  "$link"
   else
-    mpv "$link"
+    mpv --input-ipc-server=$HOME/.cache/mpvsocket "$link"
   fi
 }
 
 # Check if an online music process is running and send a notification, otherwise run the main function
-pkill -f http && notify-send -u low -i "$iDIR/music.png" "Online Music stopped" || main
+echo stop | socat - $HOME/.cache/mpvsocket && notify-send -u low  -i "$iDIR/music.png" "Online Music stopped" || main


### PR DESCRIPTION
Using socket means
1. You are killing the mpv you intended to not just "any" process that match description of "pfkill"
2. You can write scripts to interact with mpv running in background , like turning on it's video etc. It provides that flexibility.