### PR TITLE
Used socket for better killing the process

### DIFF
--- a/config/hypr/UserScripts/RofiBeats.sh
+++ b/config/hypr/UserScripts/RofiBeats.sh
@@ -38,11 +38,11 @@ main() {
   
   # Check if the link is a playlist
   if [[ $link == *playlist* ]]; then
-    mpv --shuffle --vid=no "$link"
+    mpv --input-ipc-server=$HOME/.cache/mpvsocket --shuffle --vid=no  "$link"
   else
-    mpv "$link"
+    mpv --input-ipc-server=$HOME/.cache/mpvsocket "$link"
   fi
 }
 
 # Check if an online music process is running and send a notification, otherwise run the main function
-pkill -f http && notify-send -u low -i "$iDIR/music.png" "Online Music stopped" || main
+echo stop | socat - $HOME/.cache/mpvsocket && notify-send -u low  -i "$iDIR/music.png" "Online Music stopped" || main


### PR DESCRIPTION
# Pull Request

## Description
Using socket means
1. You are killing the mpv you intended to not just "any" process that match description of "pfkill"
2. You can write scripts to interact with mpv running in background , like turning on it's video etc. It provides that flexibility.

**Dependencies Required : socat**
Available on all major linux platform

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [x] **Other** (provide details below)

Nothing was buggy per-say before, but `pfkill -f http` kills all process with filter of "http" works well till the time you have only mpv as the culprit
## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] I want to add something in Hyprland-Dots wiki.
