### PR TITLE
Bug: Pywal swww multi monitor

### DIFF
--- a/config/hypr/scripts/PywalSwww.sh
+++ b/config/hypr/scripts/PywalSwww.sh
@@ -11,30 +11,27 @@ monitor_outputs=($(ls "$cache_dir"))
 # Initialize a flag to determine if the ln command was executed
 ln_success=false
 
-# Loop through monitor outputs
-for output in "${monitor_outputs[@]}"; do
-    # Construct the full path to the cache file
-    cache_file="$cache_dir$output"
+# Get first valid monitor
+current_monitor=$(hyprctl -j monitors | jq -r '.[0].name')
 
-    # Check if the cache file exists for the current monitor output
-    if [ -f "$cache_file" ]; then
-        # Get the wallpaper path from the cache file
-        wallpaper_path=$(cat "$cache_file")
+# Construct the full path to the cache file
+cache_file="$cache_dir$current_monitor"
 
-        # Copy the wallpaper to the location Rofi can access
-        if ln -sf "$wallpaper_path" "$HOME/.config/rofi/.current_wallpaper"; then
-            ln_success=true  # Set the flag to true upon successful execution
-        fi
-
-        break  # Exit the loop after processing the first found monitor output
+# Check if the cache file exists for the current monitor output
+if [ -f "$cache_file" ]; then
+    # Get the wallpaper path from the cache file
+    wallpaper_path=$(cat "$cache_file")
+    # Copy the wallpaper to the location Rofi can access
+    if ln -sf "$wallpaper_path" "$HOME/.config/rofi/.current_wallpaper"; then
+        ln_success=true  # Set the flag to true upon successful execution
     fi
-done
+fi
 
 # Check the flag before executing further commands
 if [ "$ln_success" = true ]; then
     # execute pywal
     # wal -i "$wallpaper_path"
-
+	echo 'about to execute wal'
     # execute pywal skipping tty and terminal changes
     wal -i "$wallpaper_path" -s -t &
 fi

--- a/config/hypr/scripts/PywalSwww.sh
+++ b/config/hypr/scripts/PywalSwww.sh
@@ -31,7 +31,7 @@ fi
 if [ "$ln_success" = true ]; then
     # execute pywal
     # wal -i "$wallpaper_path"
-	echo 'about to execute wal'
+	
     # execute pywal skipping tty and terminal changes
     wal -i "$wallpaper_path" -s -t &
 fi


### PR DESCRIPTION
# Pull Request

## Description

Please read these instructions and remove unnecessary text.

- Try to include a summary of the changes and which issue is fixed.
- Also include relevant motivation and context (if applicable).
- List any dependencies that are required for this change. (e.g., packages or other PRs)
- Provide a link if there is an issue related to this pull request. e.g., Fixes # (issue)
- Please add Reviewers, Assignees, Labels, Projects, and Milestones to the PR. (if applicable)

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

(if appropriate)

## Additional context

I am using a laptop usually docked with two external monitors. When changing wallpapers, PywalSwww.sh only takes the first monitor in the cache. The issue I found is when undocking my laptop and changing wallpapers, ~/.config/rofi/.current_wallpaper is not updated correctly. This is due to the fact that first monitor in the $monitor_outputs i.e. DP-3 in my case is not my laptop monitor i.e. eDP-1 but the script exits the loop after the first monitor. So in effect the wallpaper changes as expected but the theming is stuck on whatever the the first monitor wallpaper was set to in the cache.

![image](https://github.com/JaKooLit/Hyprland-Dots/assets/79326585/65cb5a54-b624-4e57-8c0b-b3e647efe4d0)

My proposed fix is to use the first valid monitor instead using hyprctl monitors. 