### PR TITLE
fix: make pywall pickup correct output if monitor is disabled

### DIFF
--- a/config/hypr/scripts/PywalSwww.sh
+++ b/config/hypr/scripts/PywalSwww.sh
@@ -4,6 +4,7 @@
 
 # Define the path to the swww cache directory
 cache_dir="$HOME/.cache/swww/"
+laptop_display_file="$HOME/.config/hypr/UserConfigs/LaptopDisplay.conf"
 
 # Get a list of monitor outputs
 monitor_outputs=($(ls "$cache_dir"))
@@ -26,7 +27,10 @@ for output in "${monitor_outputs[@]}"; do
             ln_success=true  # Set the flag to true upon successful execution
         fi
 
-        break  # Exit the loop after processing the first found monitor output
+        # Check if the laptop display is not disabled
+		if grep -q "preffered" $laptop_display_file; then
+			break
+		fi
     fi
 done
 


### PR DESCRIPTION
# Pull Request

## Description
This simple change fixes Pywall picking up wrong output when laptop display is disabled. 

The idea behind it is in case when LaptopDisplay.conf is used (or left commented as by default) the behaviour will remain the same (loop breaks => pywall picks up first monitor output). In the case when Laptop.conf solution is used with lid switch loop continues and last monitor output gets picked up by Pywall. In-built display is always first thus this means that last for loop iteration should represent connected monitor.

Tested both with Laptop display and connected HDMI monitor&disabled laptop display. Do not have ability to test with multiple monitors unfortunately. 
## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
