### PR TITLE
dont put discord, firefox, etc on other workspaces

### DIFF
--- a/config/hypr/UserConfigs/WindowRules.conf
+++ b/config/hypr/UserConfigs/WindowRules.conf
@@ -18,20 +18,6 @@ windowrule = float, yad
 
 windowrule = center,^(pavucontrol) 
 
-# windowrule v2
-windowrulev2 = workspace 1, class:^(thunderbird)$
-windowrulev2 = workspace 2, class:^(firefox)$
-windowrulev2 = workspace 2, class:^(Firefox-esr)$
-windowrulev2 = workspace 2, class:^(Microsoft-edge-beta)$ 
-windowrulev2 = workspace 3, class:^([Tt]hunar)$
-windowrulev2 = workspace 4, class:^(com.obsproject.Studio)$
-windowrulev2 = workspace 5 silent, class:^([Ss]team)$,title:^([Ss]team)$
-windowrulev2 = workspace 5 silent, class:^(lutris)$
-windowrulev2 = workspace 6, class:^(virt-manager)$
-windowrulev2 = workspace 7 silent, class:^(discord)$
-windowrulev2 = workspace 7 silent, class:^(WebCord)$
-windowrulev2 = workspace 9 silent, class:^([Aa]udacious)$
-
 #opacity (transparent) #enable as desired
 windowrulev2 = opacity 0.9 0.6, class:^([Rr]ofi)$
 windowrulev2 = opacity 0.9 0.7, class:^(Brave-browser)$


### PR DESCRIPTION
Please dont put my discord on workspace 7
I dont think other people will enjoy not knowing where discord launched
If you still want it for your own use you may want to not accept this pull request but i think it's better to get this fixed