### PR TITLE
Fix workspace navigation for french keyboard layout

### DIFF
--- a/config/hypr/configs/Keybinds.conf
+++ b/config/hypr/configs/Keybinds.conf
@@ -106,43 +106,44 @@ bind = $mainMod SHIFT, tab, workspace, m-1
 bind = $mainMod SHIFT, U, movetoworkspace, special
 bind = $mainMod, U, togglespecialworkspace,
 
+# The following mappings use the key codes to better support various keyboard layouts
 # Switch workspaces with mainMod + [0-9]
-bind = $mainMod, 1, workspace, 1
-bind = $mainMod, 2, workspace, 2
-bind = $mainMod, 3, workspace, 3
-bind = $mainMod, 4, workspace, 4
-bind = $mainMod, 5, workspace, 5
-bind = $mainMod, 6, workspace, 6
-bind = $mainMod, 7, workspace, 7
-bind = $mainMod, 8, workspace, 8
-bind = $mainMod, 9, workspace, 9
-bind = $mainMod, 0, workspace, 10
+bind = $mainMod, code:10, workspace, 1
+bind = $mainMod, code:11, workspace, 2
+bind = $mainMod, code:12, workspace, 3
+bind = $mainMod, code:13, workspace, 4
+bind = $mainMod, code:14, workspace, 5
+bind = $mainMod, code:15, workspace, 6
+bind = $mainMod, code:16, workspace, 7
+bind = $mainMod, code:17, workspace, 8
+bind = $mainMod, code:18, workspace, 9
+bind = $mainMod, code:19, workspace, 10
 
 # Move active window and follow to workspace
-bind = $mainMod SHIFT, 1, movetoworkspace, 1
-bind = $mainMod SHIFT, 2, movetoworkspace, 2
-bind = $mainMod SHIFT, 3, movetoworkspace, 3
-bind = $mainMod SHIFT, 4, movetoworkspace, 4
-bind = $mainMod SHIFT, 5, movetoworkspace, 5
-bind = $mainMod SHIFT, 6, movetoworkspace, 6
-bind = $mainMod SHIFT, 7, movetoworkspace, 7
-bind = $mainMod SHIFT, 8, movetoworkspace, 8
-bind = $mainMod SHIFT, 9, movetoworkspace, 9
-bind = $mainMod SHIFT, 0, movetoworkspace, 10
+bind = $mainMod SHIFT, code:10, movetoworkspace, 1
+bind = $mainMod SHIFT, code:11, movetoworkspace, 2
+bind = $mainMod SHIFT, code:12, movetoworkspace, 3
+bind = $mainMod SHIFT, code:13, movetoworkspace, 4
+bind = $mainMod SHIFT, code:14, movetoworkspace, 5
+bind = $mainMod SHIFT, code:15, movetoworkspace, 6
+bind = $mainMod SHIFT, code:16, movetoworkspace, 7
+bind = $mainMod SHIFT, code:17, movetoworkspace, 8
+bind = $mainMod SHIFT, code:18, movetoworkspace, 9
+bind = $mainMod SHIFT, code:19, movetoworkspace, 10
 bind = $mainMod SHIFT, bracketleft, movetoworkspace, -1 # brackets [ or ]
 bind = $mainMod SHIFT, bracketright, movetoworkspace, +1
 
 # Move active window to a workspace silently
-bind = $mainMod CTRL, 1, movetoworkspacesilent, 1
-bind = $mainMod CTRL, 2, movetoworkspacesilent, 2
-bind = $mainMod CTRL, 3, movetoworkspacesilent, 3
-bind = $mainMod CTRL, 4, movetoworkspacesilent, 4
-bind = $mainMod CTRL, 5, movetoworkspacesilent, 5
-bind = $mainMod CTRL, 6, movetoworkspacesilent, 6
-bind = $mainMod CTRL, 7, movetoworkspacesilent, 7
-bind = $mainMod CTRL, 8, movetoworkspacesilent, 8
-bind = $mainMod CTRL, 9, movetoworkspacesilent, 9
-bind = $mainMod CTRL, 0, movetoworkspacesilent, 10
+bind = $mainMod CTRL, code:10, movetoworkspacesilent, 1
+bind = $mainMod CTRL, code:11, movetoworkspacesilent, 2
+bind = $mainMod CTRL, code:12, movetoworkspacesilent, 3
+bind = $mainMod CTRL, code:13, movetoworkspacesilent, 4
+bind = $mainMod CTRL, code:14, movetoworkspacesilent, 5
+bind = $mainMod CTRL, code:15, movetoworkspacesilent, 6
+bind = $mainMod CTRL, code:16, movetoworkspacesilent, 7
+bind = $mainMod CTRL, code:17, movetoworkspacesilent, 8
+bind = $mainMod CTRL, code:18, movetoworkspacesilent, 9
+bind = $mainMod CTRL, code:19, movetoworkspacesilent, 10
 bind = $mainMod CTRL, bracketleft, movetoworkspacesilent, -1 # brackets [ or ]
 bind = $mainMod CTRL, bracketright, movetoworkspacesilent, +1
 


### PR DESCRIPTION
# Pull Request

## Description

Some non-english keyboard layouts such as french keyboard layout do not support switching desktop with the current mapping `SUPER + [0-9]`. Instead, we need to use the keycodes linked to those 10 keys. This change doesn't break other layouts, it just fixes `workspace`, `movetoworkspace` and `movetoworkspacesilent` actions for (at least) french keyboard layout.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Additional context

I fixed this issue by following the instructions in this [blog post](https://rherault.dev/articles/hyprland-fr-layout). 
