### PR TITLE
Window rules added to make some apps transparent and float

### DIFF
--- a/config/hypr/UserConfigs/WindowRules.conf
+++ b/config/hypr/UserConfigs/WindowRules.conf
@@ -11,6 +11,8 @@ windowrule = float, zoom
 windowrule = float, rofi
 windowrule = float, gnome-system-monitor
 windowrule = float, yad
+windowrule = float, ^(wihotspot-gui)$ # wifi hotspot
+windowrule = float, ^(evince)$ # document viewer
 
 #windowrule = noblur,gamescope
 #windowrule = fullscreen,gamescope
@@ -48,6 +50,14 @@ windowrulev2 = opacity 0.9 0.7, class:^(VSCodium)$
 windowrulev2 = opacity 0.9 0.7, class:^(yad)$
 windowrulev2 = opacity 0.9 0.7, class:^(com.obsproject.Studio)$
 windowrulev2 = opacity 0.9 0.7, class:^([Aa]udacious)$
+windowrulev2 = opacity 0.9 0.8, class:^(google-chrome)$
+windowrulev2 = opacity 0.94 0.86, class:^(chrome-.+-Default)$ # Chrome PWAs
+windowrulev2 = opacity 0.9 0.8, class:^(org.gnome.Nautilus)$
+windowrulev2 = opacity 0.9 0.8, class:^(code-url-handler)$
+windowrulev2 = opacity 0.9 0.8, class:^(VSCode)$
+windowrulev2 = opacity 0.94 0.86, class:^(discord)$
+windowrulev2 = opacity 0.94 0.86, class:^(gnome-disks)$
+windowrulev2 = opacity 0.9 0.8, class:^(org.gnome.baobab)$
 
 
 #layerrule = unset,class:^([Rr]ofi)$


### PR DESCRIPTION
# Pull Request
Added Window opacity rules for commonly used apps like Discord, VSCode, Chrome.

System utilities like GNOME document viewers, Linux Wifi Hotspot, are made to float as well.

## Summary

- linux-wifi-hotspot should float
- evince (GNOME document viewer) should float
- google-chrome should be transparent
- google-chrome web apps should as well, with extra opacity since Meet, Youtube, YT Music webapps, deal with videos
- VSCode, Discord and other GNOME apps should be transparent as well

## Type of change

Please put an `x` in the boxes that apply:

- [x] **New feature** (non-breaking change which adds functionality)


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Screenshots

![image](https://github.com/JaKooLit/Hyprland-Dots/assets/50095635/7afcb595-182c-4aff-8804-44fb1d5745d1)
![image](https://github.com/JaKooLit/Hyprland-Dots/assets/50095635/de87b0fd-dfe1-4490-9907-0d419defdf70)

