### PR TITLE
PATCH: userscripts/Sounds.sh: for Non-FHS systems, use the runtime dir

### DIFF
--- a/config/hypr/UserScripts/Sounds.sh
+++ b/config/hypr/UserScripts/Sounds.sh
@@ -33,6 +33,7 @@ fi
 # Set the directory defaults for system sounds.
 userDIR="$HOME/.local/share/sounds"
 systemDIR="/usr/share/sounds"
+systemRuntimeDIR="/run/current-system/sw/share/sounds"
 defaultTheme="freedesktop"
 
 # Prefer the user's theme, but use the system's if it doesn't exist.
@@ -41,6 +42,8 @@ if [ -d "$userDIR/$theme" ]; then
     sDIR="$userDIR/$theme"
 elif [ -d "$systemDIR/$theme" ]; then
     sDIR="$systemDIR/$theme"
+elif [ -d "$systemRuntimeDIR/$theme" ]; then
+    sDIR="$systemRuntimeDIR/$theme"
 fi
 
 # Get the theme that it inherits.

--- a/config/hypr/scripts/SwitchKeyboardLayout.sh
+++ b/config/hypr/scripts/SwitchKeyboardLayout.sh
@@ -38,7 +38,7 @@ next_index=$(( (current_index + 1) % layout_count ))
 new_layout="${layout_mapping[next_index]}"
 
 # Update the keyboard layout
-hyprctl keyword input:kb_layout "$new_layout"
+hyprctl switchxkblayout "at-translated-set-2-keyboard" "$new_layout"
 echo "$new_layout" > "$layout_f"
 
 # Notification for the new keyboard layout


### PR DESCRIPTION
## Description
On Non-FHS systems like NixOS, the system sounds are located in /run/current-system/sw/share/sounds according to XDG specification. This patch allows the script (Sounds.sh) to fallback to this directory if the sound files are not found in /usr/share/sounds or $HOME/.local/share/sounds.


## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Screenshots

