### PR TITLE
userscripts/Sounds.sh: for Non-FHS systems, use the runtime dir

### DIFF
--- a/config/hypr/UserScripts/Sounds.sh
+++ b/config/hypr/UserScripts/Sounds.sh
@@ -31,8 +31,12 @@ else
 fi
 
 # Set the directory defaults for system sounds.
+if [ -d "/run/current-system/sw/share/sounds" ]; then
+    systemDIR="/run/current-system/sw/share/sounds" # NixOS
+else
+    systemDIR="/usr/share/sounds"
+fi
 userDIR="$HOME/.local/share/sounds"
-systemDIR="/usr/share/sounds"
 defaultTheme="freedesktop"
 
 # Prefer the user's theme, but use the system's if it doesn't exist.


### PR DESCRIPTION
## Description
On Non-FHS systems like NixOS, the system sounds are located in /run/current-system/sw/share/sounds according to XDG specification. This patch allows the script (Sounds.sh) to fallback to this directory if the sound files are not found in /usr/share/sounds or $HOME/.local/share/sounds.


## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Screenshots

![image](https://github.com/JaKooLit/Hyprland-Dots/assets/50095635/cab1e0db-fb7e-4278-8b5c-cbdba9cc30f4)
