### PR TITLE
userconfigs: Add keybind for toggling nightmode using wlsunset

### DIFF
--- a/config/hypr/UserConfigs/UserKeybinds.conf
+++ b/config/hypr/UserConfigs/UserKeybinds.conf
@@ -17,6 +17,7 @@ bind = $mainMod, D, exec, pkill rofi || rofi -show drun -modi drun,filebrowser,r
 
 bind = $mainMod, Return, exec, $term  # Launch terminal
 bind = $mainMod, T, exec, $files
+bind = $mainMod, F9, exec, pkill wlsunset || wlsunset -T 4500 # for toggling night mode
 
 # User Added Keybinds
 bind = $mainMod SHIFT, O, exec, $UserScripts/ZshChangeTheme.sh # Change oh-my-zsh theme


### PR DESCRIPTION
## Description
Add a keybind (mainMod + F9) to toggle night mode using wlsunset.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **New feature** (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] My change requires a change to the documentation.
- [x] All new and existing tests passed.

## Additional context

wlsunset needs to be installed.
If this PR is approved, wlsunset needs to be added to install scripts (optionally).