### PR TITLE
fxi:touchpad updated with new hyprlang syntax

### DIFF
--- a/config/hypr/scripts/TouchPad.sh
+++ b/config/hypr/scripts/TouchPad.sh
@@ -18,7 +18,7 @@ toggle_touchpad() {
   fi
 
   notify-send -u low -i "$notif" "Touchpad $action"
-  hyprctl keyword "device:$Touchpad_Device:enabled" "$(cat "$STATUS_FILE")"
+  hyprctl keyword "device[$Touchpad_Device]:enabled" "$(cat "$STATUS_FILE")"
 }
 
 toggle_touchpad


### PR DESCRIPTION
# Pull Request

## Description

hyprlang now updated with new syntax,see [this issue](https://github.com/hyprwm/hyprlang/issues/35)
## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Additional context

because the we dont have the same device id  so i cant test,but it should be work
