### PR TITLE
Updated hypridle to launch hyprlock before sleep to have hyprlock open when waking up from suspend

### DIFF
--- a/config/hypr/hypridle.conf
+++ b/config/hypr/hypridle.conf
@@ -6,7 +6,7 @@
 general {
     # lock_cmd = notify-send "lock!"          # dbus/sysd lock command (loginctl lock-session) 
     # unlock_cmd = notify-send "unlock!"      # same as above, but unlock
-    # before_sleep_cmd = notify-send "Zzz"    # command ran before sleep
+    before_sleep_cmd = hyprlock    # command ran before sleep
     # after_sleep_cmd = notify-send "Awake!"  # command ran after sleep
     ignore_dbus_inhibit = false             # whether to ignore dbus-sent idle-inhibit requests (used by e.g. firefox or steam)
 }


### PR DESCRIPTION
Updated hypridle to launch hyprlock before sleep to have hyprlock open when waking up from suspend

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [ x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x ] My code follows the code style of this project.
- [x ] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [x ] I have added tests to cover my changes.
- [x ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

