### PR TITLE
wl-logout/layout: change to hyprlock

### DIFF
--- a/config/wlogout/layout
+++ b/config/wlogout/layout
@@ -24,13 +24,15 @@
 }
 {
     "label" : "suspend",
-    "action" : "swaylock -f && systemctl suspend",
+    // "action" : "swaylock -f && systemctl suspend",
+    "action" : "hyprlock --immediate && systemctl suspend",
     "text" : "Suspend",
     "keybind" : "u"
 }
 {
     "label" : "hibernate",
-    "action" : "swaylock -f && systemctl hibernate",
+    // "action" : "swaylock -f && systemctl hibernate",
+    "action" : "hyprlock --immediate && systemctl hibernate",
     "text" : "Hibernate",
     "keybind" : "h"
 }


### PR DESCRIPTION
## Description
In wl-logout interface, use hyprlock interface instead of swaylock.

This was pending since main configuration in dev branch already switched to hyprlock.