### PR TITLE
wl-logout/layout: no need to invoke hyprlock seperately

### DIFF
--- a/config/wlogout/layout
+++ b/config/wlogout/layout
@@ -24,15 +24,13 @@
 }
 {
     "label" : "suspend",
-    // "action" : "swaylock -f && systemctl suspend",
-    "action" : "hyprlock --immediate && systemctl suspend",
+    "action" : "systemctl suspend",
     "text" : "Suspend",
     "keybind" : "u"
 }
 {
     "label" : "hibernate",
-    // "action" : "swaylock -f && systemctl hibernate",
-    "action" : "hyprlock --immediate && systemctl hibernate",
+    "action" : "systemctl hibernate",
     "text" : "Hibernate",
     "keybind" : "h"
 }


### PR DESCRIPTION
## Changes 
1. Invoking hyprlock before systemctl seem to hang the "process of hibernate/suspend" .
If we invoke hyprlock first, password needs to be entered then it will invoke systemctl hibernate/suspend so, no need to invoke hyprlock separately.

2. Remove comments as wl-logout does not support "comments", it fails to start with comments