### PR TITLE
window-rules: add transparency for google-chrome-beta,dev and more apps

### DIFF
--- a/config/hypr/UserConfigs/WindowRules.conf
+++ b/config/hypr/UserConfigs/WindowRules.conf
@@ -13,6 +13,7 @@ windowrule = float, gnome-system-monitor
 windowrule = float, yad
 windowrule = float, ^(wihotspot-gui)$ # wifi hotspot
 windowrule = float, ^(evince)$ # document viewer
+windowrule = float, ^(file-roller)$ # archive manager
 
 #windowrule = noblur,gamescope
 #windowrule = fullscreen,gamescope
@@ -45,6 +46,8 @@ windowrulev2 = opacity 0.9 0.7, class:^(Firefox-esr)$
 windowrulev2 = opacity 0.9 0.8, class:^([Tt]hunar)$
 windowrulev2 = opacity 0.8 0.6, class:^(pcmanfm-qt)$
 windowrulev2 = opacity 0.9 0.7, class:^(gedit)$
+windowrulev2 = opacity 0.9 0.8, class:^(deluge)$
+windowrulev2 = opacity 0.9 0.8, class:^(Alacritty)$
 windowrulev2 = opacity 0.9 0.8, class:^(kitty)$
 windowrulev2 = opacity 0.9 0.7, class:^(mousepad)$
 windowrulev2 = opacity 0.9 0.7, class:^(codium-url-handler)$
@@ -53,14 +56,19 @@ windowrulev2 = opacity 0.9 0.7, class:^(yad)$
 windowrulev2 = opacity 0.9 0.7, class:^(com.obsproject.Studio)$
 windowrulev2 = opacity 0.9 0.7, class:^([Aa]udacious)$
 windowrulev2 = opacity 0.9 0.8, class:^(google-chrome)$
+windowrulev2 = opacity 0.9 0.8, class:^(google-chrome-beta)$
+windowrulev2 = opacity 0.9 0.8, class:^(google-chrome-dev)$
+windowrulev2 = opacity 0.9 0.8, class:^(google-chrome-unstable)$
 windowrulev2 = opacity 0.94 0.86, class:^(chrome-.+-Default)$ # Chrome PWAs
 windowrulev2 = opacity 0.9 0.8, class:^(org.gnome.Nautilus)$
 windowrulev2 = opacity 0.9 0.8, class:^(code-url-handler)$
 windowrulev2 = opacity 0.9 0.8, class:^(VSCode)$
+windowrulev2 = opacity 0.9 0.8, class:^(jetbrains-studio)$ # Android Studio
 windowrulev2 = opacity 0.94 0.86, class:^(discord)$
+windowrulev2 = opacity 0.9 0.8, class:^(org.telegram.desktop)$
 windowrulev2 = opacity 0.94 0.86, class:^(gnome-disks)$
 windowrulev2 = opacity 0.9 0.8, class:^(org.gnome.baobab)$
-
+windowrulev2 = opacity 0.9 0.8, class:^(seahorse)$ # gnome-keyring gui
 
 #layerrule = unset,class:^([Rr]ofi)$
 #layerrule = blur,class:^([Rr]ofi)$


### PR DESCRIPTION
Window rules added for
- Chrome Beta, Dev, Unstable
- Gnome Archive Manager
- Telegram
- Seahorse (gnome-keyring gui)
- Android Studio
- Alacritty
- Deluge

