### PR TITLE
add pyprland: with dropterm and magnify enabled

### DIFF
--- a/config/hypr/UserConfigs/Startup_Apps.conf
+++ b/config/hypr/UserConfigs/Startup_Apps.conf
@@ -37,6 +37,9 @@ exec-once = $UserScripts/RainbowBorders.sh
 # Starting hypridle to start hyprlock
 exec-once = hypridle
 
+# Start pyprland daemon
+exec-once = pypr
+
 # Here are list of features available but disabled by default
 # exec-once = swww query || swww-daemon --format xrgb && swww img $HOME/Pictures/wallpapers/mecha-nostalgia.png  # persistent wallpaper
 

--- a/config/hypr/UserConfigs/UserKeybinds.conf
+++ b/config/hypr/UserConfigs/UserKeybinds.conf
@@ -18,6 +18,10 @@ bind = $mainMod, D, exec, pkill rofi || rofi -show drun -modi drun,filebrowser,r
 bind = $mainMod, Return, exec, $term  # Launch terminal
 bind = $mainMod, T, exec, $files
 
+# pyprland
+bind = $mainMod, A, exec, pypr toggle term # Dropdown terminal
+bind = $mainMod, Z, exec, pypr zoom # Toggle Zoom
+
 # User Added Keybinds
 bind = $mainMod SHIFT, O, exec, $UserScripts/ZshChangeTheme.sh # Change oh-my-zsh theme
 

--- a/config/hypr/pyprland.toml
+++ b/config/hypr/pyprland.toml
@@ -1,0 +1,12 @@
+[pyprland]
+
+plugins = [
+  "scratchpads",
+  "magnify",
+]
+
+[scratchpads.term]
+animation = "fromTop"
+command = "kitty --class kitty-dropterm"
+class = "kitty-dropterm"
+size = "75% 60%"


### PR DESCRIPTION
## Description
Adds pyprland, a Hyprland plugin manager support.
Current features:
- Drop term (mainMod + A)
- Magnify (mainMod + Z)

## Dependencies
Just need [Pyprland](https://github.com/hyprland-community/pyprland) installed.
Documentations available [here](https://github.com/hyprland-community/pyprland/wiki/Getting-started).