### PR TITLE
Improved overview colour scheme for light and dark wallpapers and added blur

### DIFF
--- a/config/ags/user/style.css
+++ b/config/ags/user/style.css
@@ -23,16 +23,16 @@ widget {
   border-left: 1px solid @color7;
   border-right: 1px solid @color7;
   border-bottom: 1px solid @color7;
-  box-shadow: 0px 2px 3px rgba(0, 0, 0, 0.45);
+  /* box-shadow: 0px 2px 3px alpha(@color0, 0.45); */
   margin: 0.476rem;
   min-width: 13.636rem;
   min-height: 3.409rem;
   padding: 0rem 1.364rem;
   padding-right: 2.864rem;
   background-color: alpha(@color0, 0.5);
-  /* color: #EBDFED; */
   color: alpha(@color7, 0.9);
   caret-color: transparent;
+  font-weight: bold;
 }
 .overview-search-box selection {
   background-color: #DEBCDF;
@@ -45,7 +45,6 @@ widget {
 }
 
 .overview-search-prompt {
-  /* color: #988D9D; */
   color: alpha(@color7, 0.9);
 }
 
@@ -70,12 +69,13 @@ widget {
   border-left: 1px solid @color7;
   border-right: 1px solid @color7;
   border-bottom: 1px solid @color7;
-  box-shadow: 0px 2px 3px @color8;
+  box-shadow: 0px 2px 3px @color9;
   margin: 0.476rem;
   min-width: 28.773rem;
   padding: 0.682rem;
-  background-color: @color2;
-  color: #EBDFED;
+  background-color: alpha(@color2, 0.5);
+  color: alpha(@color7, 1.5);
+  font-weight: bold;
 }
 
 .overview-search-results-icon {
@@ -106,11 +106,13 @@ widget {
 
 .overview-search-result-btn:hover,
 .overview-search-result-btn:focus {
-  background-color: #2E2832;
+  background-color: alpha(@color7, 0.4);
+  color: alpha(@color0, 0.7);
 }
 
 .overview-search-result-btn:active {
-  background-color: #39323D;
+  background-color: alpha(@color7, 0.4);
+  color: @color4;
 }
 
 .overview-tasks {
@@ -124,7 +126,7 @@ widget {
   margin: 0.476rem;
   padding: 0.341rem;
   /* background-color: rgba(49, 50, 68, 0.8); */
-  background-color: alpha(@color9, 0.4);
+  background-color: alpha(@color0, 0.6);
   color: #EBDFED;
 }
 
@@ -157,15 +159,15 @@ widget {
 
 .overview-tasks-window:hover,
 .overview-tasks-window:focus {
-  background-color: @color9;
+  background-color: alpha(@color9, 0.8);
 }
 
 .overview-tasks-window:active {
-  background-color: @color9;
+  background-color: alpha(@color9, 0.8);
 }
 
 .overview-tasks-window-selected {
-  background-color: @color9;
+  background-color: alpha(@color9, 0.8);
 }
 
 .overview-tasks-window-dragging {

--- a/config/hypr/UserConfigs/WindowRules.conf
+++ b/config/hypr/UserConfigs/WindowRules.conf
@@ -83,6 +83,9 @@ windowrulev2 = opacity 0.9 0.8, class:^(seahorse)$ # gnome-keyring gui
 #layerrule = blur,class:^([Rr]ofi)$
 #layerrule = ignorezero, <rofi>
 
+layerrule = ignorezero, overview
+layerrule = blur, overview
+
 #windowrulev2 = bordercolor rgb(EE4B55) rgb(880808), fullscreen:1
 #windowrulev2 = bordercolor rgb(282737) rgb(1E1D2D), floating:1
 #windowrulev2 = opacity 0.8 0.8, pinned:1


### PR DESCRIPTION
Improved overview colour scheme for light and dark wallpapers and added blur

# Pull Request


## Type of change

Please put an `x` in the boxes that apply:

- [x ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x ] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [ x] My code follows the code style of this project.
- [ x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ x] I have added tests to cover my changes.
- [ x] I have tested my code locally and it works as expected.
- [ x] All new and existing tests passed.

## Screenshots

![image](https://github.com/JaKooLit/Hyprland-Dots/assets/26952545/50f28866-cc55-4024-ae6a-2f41530204ff)

![image](https://github.com/JaKooLit/Hyprland-Dots/assets/26952545/0cb37e93-b2fd-44a6-bca9-873c51f76bcd)

(Made it bit darker for light walls)
![image](https://github.com/JaKooLit/Hyprland-Dots/assets/26952545/a61e8b97-712d-4ab9-894e-376f73b9d986)

![image](https://github.com/JaKooLit/Hyprland-Dots/assets/26952545/7ea0d2d5-33ce-4cc1-8e24-303677d341c5)



## Additional context

Need to improve the blur for borders of the widget.
