### PR TITLE
Fixed missing vscodium icon from ags overview

### DIFF
--- a/config/ags/modules/.configuration/user_options.js
+++ b/config/ags/modules/.configuration/user_options.js
@@ -68,6 +68,7 @@ let configOptions = {
     // Longer stuff
     'icons': {
         substitutions: {
+            'codium-url-handler': "vscodium",
             'code-url-handler': "visual-studio-code",
             'Code': "visual-studio-code",
             'GitHub Desktop': "github-desktop",


### PR DESCRIPTION
# Pull Request

Saw that you were missing vscodium icon in ags in showcase video (Nice video btw :))


## Type of change

Please put an `x` in the boxes that apply:

- [x ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x ] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x ] My code follows the code style of this project.
- [x ] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

![image](https://github.com/JaKooLit/Hyprland-Dots/assets/26952545/056876b2-581e-4057-8750-79091f2cbc1e)re.
