### PR TITLE
patch-swww: at startup, always start swww-daemon explicitly

### DIFF
--- a/config/hypr/UserConfigs/Startup_Apps.conf
+++ b/config/hypr/UserConfigs/Startup_Apps.conf
@@ -9,7 +9,7 @@ $lock = $scriptsDir/LockScreen.sh
 $SwwwRandom = $UserScripts/WallpaperAutoChange.sh
 
 # wallpaper stuff / More wallpaper options below
-exec-once = swww query || swww-daemon --format xrgb
+exec-once = swww-daemon --format xrgb
 exec-once = $SwwwRandom $wallDIR # random wallpaper switcher every 30 minutes 
 
 # Startup
@@ -41,7 +41,7 @@ exec-once = hypridle &
 exec-once = pypr &
 
 # Here are list of features available but disabled by default
-# exec-once = swww query || swww-daemon --format xrgb && swww img $HOME/Pictures/wallpapers/mecha-nostalgia.png  # persistent wallpaper
+# exec-once = swww-daemon --format xrgb && swww img $HOME/Pictures/wallpapers/mecha-nostalgia.png  # persistent wallpaper
 
 #gnome polkit for nixos
 #exec-once = $scriptsDir/Polkit-NixOS.sh


### PR DESCRIPTION
## Changes
Directly launch `swww daemon`, like how [the docs suggest](https://github.com/LGFae/swww?tab=readme-ov-file#usage).
There is no need to check whether swww is running when launching Hyprland after login.

Because at system login, swww obviously won't be running. So start it.
This fixes the bug where wallpaper is not shown at system startup.