### PR TITLE
Add floating window rules for non-main Steam windows

### DIFF
--- a/config/hypr/UserConfigs/WindowRules.conf
+++ b/config/hypr/UserConfigs/WindowRules.conf
@@ -40,6 +40,7 @@ windowrulev2 = float, class:^(evince)$ # document viewer
 windowrulev2 = float, class:^(file-roller|org.gnome.FileRoller)$ # archive manager
 windowrulev2 = float, class:^([Bb]aobab|org.gnome.[Bb]aobab)$ # Disk usage analyzer
 windowrulev2 = float, title:(Kvantum Manager)
+windowrulev2 = float, class:^([Ss]team)$,title:^((?![Ss]team).*|[Ss]team [Ss]ettings)$
 
 # windowrule v2 - opacity #enable as desired
 windowrulev2 = opacity 0.9 0.6, class:^([Rr]ofi)$


### PR DESCRIPTION
Friends list and settings tiling can be annoying

# Pull Request

Add window rules to make all non-main steam windows float on current workspace, eg. friends list, chat windows and settings.

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Additional context

Note: Windows will occasionally open in a 1px by 1px window which is a known bug with [hyprland/steam windows when assigned to a workspace](https://github.com/hyprwm/Hyprland/issues/4976) but can be resized to the correct size