### PR TITLE
Correction of the keyboard layout change.

### DIFF
--- a/config/hypr/UserConfigs/UserKeybinds.conf
+++ b/config/hypr/UserConfigs/UserKeybinds.conf
@@ -27,7 +27,7 @@ bind = $mainMod, Z, exec, pypr zoom # Toggle Zoom
 
 # User Added Keybinds
 bind = $mainMod SHIFT, O, exec, $UserScripts/ZshChangeTheme.sh # Change oh-my-zsh theme
-
+bindn = ALT_L, SHIFT_L, exec, $scriptsDir/SwitchKeyboardLayout.sh
 # For passthrough keyboard into a VM
 # bind = $mainMod ALT, P, submap, passthru
 #submap = passthru

--- a/config/hypr/UserConfigs/UserKeybinds.conf
+++ b/config/hypr/UserConfigs/UserKeybinds.conf
@@ -27,7 +27,8 @@ bind = $mainMod, Z, exec, pypr zoom # Toggle Zoom
 
 # User Added Keybinds
 bind = $mainMod SHIFT, O, exec, $UserScripts/ZshChangeTheme.sh # Change oh-my-zsh theme
-bindn = ALT_L, SHIFT_L, exec, $scriptsDir/SwitchKeyboardLayout.sh
+bindn = ALT_L, SHIFT_L, exec, $scriptsDir/SwitchKeyboardLayout.sh # Changing the keyboard layout
+
 # For passthrough keyboard into a VM
 # bind = $mainMod ALT, P, submap, passthru
 #submap = passthru

--- a/config/hypr/UserConfigs/UserSettings.conf
+++ b/config/hypr/UserConfigs/UserSettings.conf
@@ -99,7 +99,7 @@ input {
   kb_layout=us
   kb_variant=
   kb_model=
-  kb_options=grp:alt_shift_toggle
+  kb_options=
   kb_rules=
   repeat_rate=50
   repeat_delay=300

--- a/config/hypr/scripts/SwitchKeyboardLayout.sh
+++ b/config/hypr/scripts/SwitchKeyboardLayout.sh
@@ -41,5 +41,38 @@ new_layout="${layout_mapping[next_index]}"
 hyprctl switchxkblayout "at-translated-set-2-keyboard" "$new_layout"
 echo "$new_layout" > "$layout_f"
 
-# Notification for the new keyboard layout
-notify-send -u low -i "$notif" "new KB_Layout: $new_layout"
+# Created by T-Crypt
+
+get_keyboard_names() {
+    hyprctl devices -j | jq -r '.keyboards[].name'
+}
+
+change_layout() {
+    local got_error=false
+
+    while read -r name; do
+        hyprctl switchxkblayout "$name" next
+        if [[ $? -eq 0 ]]; then
+            echo "Switched the layout for $name."
+        else
+            >&2 echo "Error while switching the layout for $name."
+            got_error=true
+        fi
+    done <<< "$(get_keyboard_names)"
+
+    if [ "$got_error" = true ]; then
+        >&2 echo "Some errors were found during the process..."
+        return 1
+    fi
+
+    return 0 # All layouts had been cycled successfully
+}
+
+if ! change_layout; then
+    notify-send -u low -t 2000 'Keyboard layout' 'Error: Layout change failed'
+    >&2 echo "Layout change failed."
+    exit 1
+else
+    # Notification for the new keyboard layout
+	  notify-send -u low -i "$notif" "new KB_Layout: $new_layout"
+fi


### PR DESCRIPTION
# Pull Request

## Description

Fixed the problem of switching the keyboard layout on different keyboards connected to the computer. Previously, switching the layout worked for each connected keyboard individually, now it works for all connected keyboards, regardless of where the layout is switched. The waybar widget with notification has also been fixed.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [x] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Additional context

If the layout in the widget does not match the current keyboard layout, run: `echo "us" > ./.cache/kb_layout` instead of "us", put the identifier of the current keyboard layout, for example "ru" or "en" or "ua", etc.
