### PR TITLE
window-rules: add Vesktop, JetBrains IDEs, and Warp file transfer

### DIFF
--- a/config/hypr/UserConfigs/WindowRules.conf
+++ b/config/hypr/UserConfigs/WindowRules.conf
@@ -17,6 +17,7 @@ windowrulev2 = workspace 5, class:^([Ss]team)$
 windowrulev2 = workspace 5, class:^([Ll]utris)$
 windowrulev2 = workspace 7, class:^([Dd]iscord)$
 windowrulev2 = workspace 7, class:^([Ww]ebCord)$
+windowrulev2 = workspace 7, class:^([Vv]esktop)$
 
 # windowrule v2 move to workspace (silent)
 windowrulev2 = workspace 6 silent, class:^(virt-manager)$
@@ -70,12 +71,12 @@ windowrulev2 = opacity 0.9 0.7, class:^(com.obsproject.Studio)$
 windowrulev2 = opacity 0.9 0.7, class:^([Aa]udacious)$
 windowrulev2 = opacity 0.9 0.8, class:^(org.gnome.Nautilus)$
 windowrulev2 = opacity 0.9 0.8, class:^(VSCode|code-url-handler)$
-windowrulev2 = opacity 0.9 0.8, class:^(jetbrains-studio)$ # Android Studio
-windowrulev2 = opacity 0.9 0.8, class:^(jetbrains-phpstorm)$ # PHPStorm
-windowrulev2 = opacity 0.94 0.86, class:^(discord)$
-windowrulev2 = opacity 0.9 0.8, class:^(org.telegram.desktop)$
+windowrulev2 = opacity 0.9 0.8, class:^(jetbrains-.+)$ # JetBrains IDEs
+windowrulev2 = opacity 0.94 0.86, class:^([Dd]iscord|[Vv]esktop)$
+windowrulev2 = opacity 0.9 0.8, class:^(org.telegram.desktop|io.github.tdesktop_x64.TDesktop)$
 windowrulev2 = opacity 0.94 0.86, class:^(gnome-disks|evince|wihotspot-gui|org.gnome.baobab)$
 windowrulev2 = opacity 0.9 0.8, class:^(file-roller|org.gnome.FileRoller)$ # archive manager
+windowrulev2 = opacity 0.8 0.7, class:^(app.drey.Warp)$ # Warp file transfer
 windowrulev2 = opacity 0.9 0.8, class:^(seahorse)$ # gnome-keyring gui
 windowrulev2 = opacity 0.82 0.75, class:^(gnome-system-monitor|org.gnome.SystemMonitor)$
 windowrulev2 = opacity 0.9 0.8, class:^(xdg-desktop-portal-gtk)$ # gnome-keyring gui


### PR DESCRIPTION
## Changes
Add the window and transparency rules for: 

- Include all JetBrains IDEs by using a regex
- Add 64Gram, a telegram client
- Added Vesktop, a Discord client
- Warp file transfer
