### PR TITLE
fastfetch: add config-compact.jsonc

### DIFF
--- a/config/fastfetch/config-compact.jsonc
+++ b/config/fastfetch/config-compact.jsonc
@@ -1,0 +1,63 @@
+{
+    "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json",
+    "logo": {
+        "type": "small"
+    },
+    "display": {
+        "separator": " -> "
+    },
+    "modules": [
+        "break",
+        {
+            "type": "custom",
+            "format": " ╭───────┤ \u001b[35m\u001b[1m NixOS\u001b[0m ├───────╮"
+        },
+        {
+            "type": "kernel",
+            "key": " ",
+            "keyColor": "yellow"
+        },
+        {
+            "type": "wm",
+            "key": " ",
+            "keyColor": "blue"
+        },
+        {
+            "type": "shell",
+            "key": " ",
+            "keyColor": "yellow"
+        },
+        {
+            "type": "terminal",
+            "key": " ",
+            "keyColor": "blue"
+        },
+        /*
+        {
+            "type": "packages",
+            "key": "󰏖 ",
+            "keyColor": "yellow"
+        },
+        */
+        {
+            "type": "memory",
+            "key": "󰍛 ",
+            "keyColor": "green",
+            // format: used / total
+            "format": "{1} / {2}"
+        },
+        {
+            "type": "uptime",
+            "key": "󰔛 ",
+            "keyColor": "green"
+        },
+        {
+            "type": "custom",
+            "format": " ╰─────────────────────────╯"
+        },
+        {
+            "type": "custom",
+            "format": "   \u001b[31m  \u001b[32m  \u001b[33m  \u001b[34m  \u001b[35m  \u001b[36m  \u001b[37m  \u001b[30m "
+        }
+    ]
+}

--- a/config/fastfetch/config-compact.jsonc
+++ b/config/fastfetch/config-compact.jsonc
@@ -1,6 +1,9 @@
 {
     "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json",
     "logo": {
+        "padding": {
+            "top": 2
+        },
         "type": "small"
     },
     "display": {
@@ -9,8 +12,13 @@
     "modules": [
         "break",
         {
+            "type": "title",
+            "keyWidth": 10,
+			"format": "         {6}{7}{8}"
+        },
+        {
             "type": "custom",
-            "format": " ╭───────┤ \u001b[35m\u001b[1m NixOS\u001b[0m ├───────╮"
+            "format": "  ╭───────────────────────╮"
         },
         {
             "type": "kernel",
@@ -42,7 +50,7 @@
         {
             "type": "memory",
             "key": "󰍛 ",
-            "keyColor": "green",
+            "keyColor": "magenta",
             // format: used / total
             "format": "{1} / {2}"
         },
@@ -53,11 +61,12 @@
         },
         {
             "type": "custom",
-            "format": " ╰─────────────────────────╯"
+            "format": "  ╰───────────────────────╯"
         },
         {
             "type": "custom",
-            "format": "   \u001b[31m  \u001b[32m  \u001b[33m  \u001b[34m  \u001b[35m  \u001b[36m  \u001b[37m  \u001b[30m "
-        }
+            "format": "   \u001b[31m  \u001b[32m  \u001b[33m  \u001b[34m  \u001b[35m  \u001b[36m  \u001b[37m  \u001b[90m "
+        },
+		"break",
     ]
 }


### PR DESCRIPTION
## Changes
- Added compact config for fastfetch.
- It can be easily used by setting an alias

```bash
alias cfastfetch="fastfetch --config ~/.config/fastfetch/config-compact.jsonc"
```

![image](https://github.com/JaKooLit/Hyprland-Dots/assets/50095635/62b57e98-444f-4833-addc-23dcdc4ca5a3)
