### PR TITLE
Fix: added alternative pavucontrol class name in WindowRules

### DIFF
--- a/config/hypr/UserConfigs/WindowRules.conf
+++ b/config/hypr/UserConfigs/WindowRules.conf
@@ -5,7 +5,7 @@
 #windowrule = fullscreen,gamescope
 #windowrule = workspace 6 silent,^(gamescope)$
 
-windowrule = center,^(pavucontrol)
+windowrule = center,^(pavucontrol|org.pulseaudio.pavucontrol)$
 
 # windowrule v2 move to workspace
 windowrulev2 = workspace 1, class:^([Tt]hunderbird)$
@@ -33,7 +33,7 @@ windowrulev2 = float, class:(org.gnome.Calculator), title:(Calculator)
 windowrulev2 = float, class:(codium|codium-url-handler|VSCodium), title:(Add Folder to Workspace)
 windowrulev2 = float, class:^([Rr]ofi)$
 windowrulev2 = float, class:^(eog)$
-windowrulev2 = float, class:^(pavucontrol)$
+windowrulev2 = float, class:^(pavucontrol|org.pulseaudio.pavucontrol)$
 windowrulev2 = float, class:^(nwg-look|qt5ct|qt6ct|mpv)$
 windowrulev2 = float, class:^(nm-applet|nm-connection-editor|blueman-manager)$
 windowrulev2 = float, class:^(gnome-system-monitor|org.gnome.SystemMonitor)$ # system monitor


### PR DESCRIPTION
# Pull Request

## Description

I just got a pavucontrol update on arch to version 1.6. This changed the window class name to "org.pulseaudio.pavucontrol".

This PR just adds that as an alterative to the 2 WindowRules in the UserConfig.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

(if appropriate)

## Additional context

Add any other context about the problem here.
