### PR TITLE
fix: remove cause of hyprlock crashing (caused by multiple instances of hyprlock running) + misc. Hypridle.conf changes

### DIFF
--- a/config/hypr/hypridle.conf
+++ b/config/hypr/hypridle.conf
@@ -4,12 +4,20 @@
                                                       
 
 general {
-    # lock_cmd = notify-send "lock!"          # dbus/sysd lock command (loginctl lock-session) 
-    # unlock_cmd = notify-send "unlock!"      # same as above, but unlock
-    before_sleep_cmd = hyprlock    # command ran before sleep
-    # after_sleep_cmd = notify-send "Awake!"  # command ran after sleep
+    lock_cmd = pidof hyprlock || hyprlock # runs hyprlock if it is not already running (this is always run when "loginctl lock-session" is called) 
+    # unlock_cmd = killall hyprlock # kills hyprlock when unlocking (this is always run when "loginctl unlock-session" is called)
+    before_sleep_cmd = loginctl lock-session    # ensures that the session is locked before going to sleep
+    after_sleep_cmd = hyprctl dispatch dpms on # turn of screen after sleep (not strictly necessary, but just in case)
     ignore_dbus_inhibit = false             # whether to ignore dbus-sent idle-inhibit requests (used by e.g. firefox or steam)
 }
+
+# turn off screen faster if session is already locked
+# (disabled by default)
+# listener {
+#     timeout = 30                            # 30 seconds
+#     on-timeout = pidof hyprlock && hyprctl dispatch dpms off # turns off the screen if hyprlock is active
+#     on-resume = pidof hyprlock && hyprctl dispatch dpms on    # command to run when activity is detected after timeout has fired.
+# }
 
 # Warn
 listener {
@@ -21,9 +29,17 @@ listener {
 # Screenlock
 listener {
     timeout = 600                     # 10 min
-    on-timeout = hyprlock # command to run when timeout has passed
+    on-timeout = loginctl lock-session # command to run when timeout has passed
     # on-resume = notify-send "Welcome back to your desktop!"  # command to run when activity is detected after timeout has fired.
 }
+
+# Turn off screen 
+# (disabled by default)
+# listener {
+#     timeout = 630                            # 10.5 min
+#     on-timeout = hyprctl dispatch dpms off  # command to run when timeout has passed
+#     on-resume = hyprctl dispatch dpms on    # command to run when activity is detected after timeout has fired.
+# }
 
 # Suspend # disabled by default
 # listener {

--- a/config/hypr/scripts/LockScreen.sh
+++ b/config/hypr/scripts/LockScreen.sh
@@ -2,4 +2,4 @@
 # /* ---- 💫 https://github.com/JaKooLit 💫 ---- */  ##
 
 # For Hyprlock
-hyprlock -q --immediate
+pidof hyprlock || hyprlock -q --immediate


### PR DESCRIPTION
# Pull Request

## Description

changed hypridle.conf and LockScreen.sh so hyprlock won't be called if it is already running, as that renders all hyprlock instances useless. (checkable by pressing Ctrl + Alt + L twice, only killall hyprlock fixes this.)

"loginctl lock-session" now calls hyprlock and "loginctl unlock-session" kills hyprlock. (in case someone has a program that calls the generic commands or follows am online guide in tty or something if they are having problems with hyprlock)

Add a automatic hyprlock call when going to sleep as well as turning the screen on after waking up.

Copied 2 listeners to turn off the screen from my personal config. One after locking the display and the other doing this faster in case hyprlock is already running.

I commented out the 2 listeners as they would change the default behavior.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Additional context

Add any other context about the problem here.
