### PR TITLE
fix: improvement to brightness script

### DIFF
--- a/config/hypr/scripts/Brightness.sh
+++ b/config/hypr/scripts/Brightness.sh
@@ -33,7 +33,7 @@ notify_user() {
 
 # Change brightness
 change_backlight() {
-	brightnessctl set "$1" && get_icon && notify_user
+	brightnessctl set "$1" -n && get_icon && notify_user
 }
 
 # Execute accordingly


### PR DESCRIPTION
# Pull Request

## Description

`Brightness.sh` was not using the `-n`/`--min-value` flag for `brightnessctl`. This was causing the raw brightness value to reach 0 if you kept decreasing brightness, leaving  a completly black screen.

Adding this flag leaves the brightness at raw value 1 (minimum possible brightness for screen to be readable), instead of letting it reach 0.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

N/A

## Additional context

N/A
