### PR TITLE
fix: Invalid regex for fullscreen idleinhibit windowrulev2's title

### DIFF
--- a/config/hypr/UserConfigs/WindowRules.conf
+++ b/config/hypr/UserConfigs/WindowRules.conf
@@ -17,8 +17,8 @@ windowrulev2 = center, class:([Tt]hunar), title:(File Operation Progress)
 windowrulev2 = center, class:([Tt]hunar), title:(Confirm to replace files)
 
 # windowrule v2 to avoid idle for fullscreen apps
-windowrulev2 = idleinhibit fullscreen, class:^(*)$
-windowrulev2 = idleinhibit fullscreen, title:^(*)$
+windowrulev2 = idleinhibit fullscreen, class:^(.*)$
+windowrulev2 = idleinhibit fullscreen, title:^(.*)$
 windowrulev2 = idleinhibit fullscreen, fullscreen:1
 
 # windowrule v2 move to workspace


### PR DESCRIPTION
# Pull Request

## Description

The windowrulev2 for fullscreen idleinhibit has an invalid regex expression for title which throws an error along the lines `[ERR] Regex error at  title:^(*)$ (Mismatched '(' and ')' in regular expression)` in the logs. The correct regex pattern should include a "match any character" (`.`) before the Kleene star (`*`).

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.