### PR TITLE
Adjusted Brightness.sh to add step option and fixed rounding error.

### DIFF
--- a/config/hypr/scripts/Brightness.sh
+++ b/config/hypr/scripts/Brightness.sh
@@ -4,6 +4,7 @@
 
 iDIR="$HOME/.config/swaync/icons"
 notification_timeout=1000
+step=10  # INCREASE/DECREASE BY THIS VALUE
 
 # Get brightness
 get_backlight() {
@@ -37,10 +38,10 @@ change_backlight() {
 	current_brightness=$(get_backlight)
 
 	# Calculate new brightness
-	if [[ "$1" == "+5%" ]]; then
-		new_brightness=$((current_brightness + 5))
-	elif [[ "$1" == "5%-" ]]; then
-		new_brightness=$((current_brightness - 5))
+	if [[ "$1" == "+${step}%" ]]; then
+		new_brightness=$((current_brightness + step))
+	elif [[ "$1" == "${step}%-" ]]; then
+		new_brightness=$((current_brightness - step))
 	fi
 
 	# Ensure new brightness is within valid range
@@ -62,10 +63,10 @@ case "$1" in
 		get_backlight
 		;;
 	"--inc")
-		change_backlight "+5%"
+		change_backlight "+${step}%"
 		;;
 	"--dec")
-		change_backlight "5%-"
+		change_backlight "${step}%-"
 		;;
 	*)
 		get_backlight


### PR DESCRIPTION
# Pull Request

## Description
Added option to change step value for brightness and fixed a rounding error which caused values to be incorrect at smaller step sizes, such as 5. It occasionally made it step by 6 or 4 sometimes.
Please read these instructions and remove unnecessary text.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [x] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Screenshots

N/A

## Additional context
You can change by how much it changes the brightness when using brightness keys on your laptop by editing the step variable in `~/.config/hypr/scripts/Brightness.sh`. Also if you decided to change it to 5, it will fix an error which made the brightness change values inconsistent.
