### PR TITLE
Waybar is no longer refreshed when selecting a random wallpaper

### DIFF
--- a/config/hypr/UserScripts/WallpaperRandom.sh
+++ b/config/hypr/UserScripts/WallpaperRandom.sh
@@ -24,5 +24,5 @@ swww query || swww-daemon --format xrgb && swww img -o $focused_monitor ${RANDOM
 
 ${scriptsDir}/WallustSwww.sh
 sleep 1
-${scriptsDir}/Refresh.sh 
+${scriptsDir}/RefreshNoWaybar.sh 
 

--- a/config/hypr/UserScripts/WallpaperSelect.sh
+++ b/config/hypr/UserScripts/WallpaperSelect.sh
@@ -93,4 +93,4 @@ main
 sleep 0.5
 ${SCRIPTSDIR}/WallustSwww.sh
 sleep 0.2
-${SCRIPTSDIR}/Refresh.sh
+${SCRIPTSDIR}/RefreshNoWaybar.sh

--- a/config/hypr/scripts/RefreshNoWaybar.sh
+++ b/config/hypr/scripts/RefreshNoWaybar.sh
@@ -2,7 +2,7 @@
 # /* ---- 💫 https://github.com/JaKooLit 💫 ---- */  ##
 
 # Modified version of Refresh but no waybar refresh
-# Used by automatic wallpaper change
+# Used by automatic wallpaper change and random wallpaper
 # Modified inorder to refresh rofi background, Wallust, SwayNC
 
 SCRIPTSDIR=$HOME/.config/hypr/scripts


### PR DESCRIPTION
# Pull Request

## Description
The waybar is no longer refreshed when changing the wallpaper to a random one via `CTRL + ALT + W` or from `SUPER + W`. It uses the `RefreshNoWaybar` script instead, which is already used by the `WallpaperAutoChange` script.
## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [x] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Screenshots

N/A

## Additional context

N/A