### PR TITLE
Show thumbnail of random wallpaper in wallpaper selector

### DIFF
--- a/config/hypr/UserScripts/WallpaperSelect.sh
+++ b/config/hypr/UserScripts/WallpaperSelect.sh
@@ -33,8 +33,8 @@ rofi_command="rofi -i -show -dmenu -config ~/.config/rofi/config-wallpaper.rasi"
 # Sorting Wallpapers
 menu() {
   sorted_options=($(printf '%s\n' "${PICS[@]}" | sort))
-  # Place ". random" at the beginning
-  printf "%s\n" "$RANDOM_PIC_NAME"
+  # Place ". random" at the beginning with the random picture as an icon
+  printf "%s\x00icon\x1f%s\n" "$RANDOM_PIC_NAME" "$RANDOM_PIC"
   for pic_path in "${sorted_options[@]}"; do
     pic_name=$(basename "$pic_path")
     # Displaying .gif to indicate animated images
@@ -59,7 +59,6 @@ main() {
 
   # Random choice case
   if [ "$choice" = "$RANDOM_PIC_NAME" ]; then
-    RANDOM_PIC="${PICS[$((RANDOM % ${#PICS[@]}))]}"
     swww img -o $focused_monitor "${RANDOM_PIC}" $SWWW_PARAMS
     exit 0
   fi


### PR DESCRIPTION
# Pull Request

## Description
Hi. This change puts the wallpaper thumbnail in the wallpaper select page instead of showing a blank screen. Now you are able to see which is going to be the next wallpaper, but it is still random because it chooses one for you.

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [x] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Screenshots

Preview: https://streamable.com/53mdh6

## Additional context

The wallpaper thumbnail will be randomized every time the menu is opened.