### PR TITLE
config: Add documentation for 10 bit color displays

### DIFF
--- a/config/hypr/UserConfigs/Monitors.conf
+++ b/config/hypr/UserConfigs/Monitors.conf
@@ -19,6 +19,11 @@ monitor=,preferred,auto,1
 #monitor = DP-1, preferred, auto, 1
 #monitor = HDMI-A-1, preferred,auto,1
 
+# NOTE: for monitors with 10 bit color displays, enable the depthbit,10 option.
+# Otherwise, screen captures might render a black screen
+
+# monitor=,preferred,auto,1,bitdepth,10
+
 # QEMU-KVM or any virtual box
 #monitor = Virtual-1, 1920x1080@60,auto,1
 

--- a/config/hypr/UserConfigs/Monitors.conf
+++ b/config/hypr/UserConfigs/Monitors.conf
@@ -5,7 +5,6 @@
 # https://wiki.hyprland.org/Configuring/Monitors/
 # Configure your Display resolution, offset, scale and Monitors here, use `hyprctl monitors` to get the info.
 
-
 # Monitors
 monitor=,preferred,auto,1
 
@@ -13,21 +12,17 @@ monitor=,preferred,auto,1
 # Created this inorder for the monitor display to not wake up if not intended.
 # See here: https://github.com/hyprwm/Hyprland/issues/4090
 
+# Some examples
 #monitor = eDP-1, preferred, auto, 1
 #monitor = eDP-1, 2560x1440@165, 0x0, 1 #own screen
 #monitor = DP-3, 1920x1080@240, auto, 1 
 #monitor = DP-1, preferred, auto, 1
 #monitor = HDMI-A-1, preferred,auto,1
 
-# NOTE: for monitors with 10 bit color displays, enable the depthbit,10 option.
-# Otherwise, screen captures might render a black screen
-
-# monitor=,preferred,auto,1,bitdepth,10
-
-# QEMU-KVM or any virtual box
+# QEMU-KVM, virtual box or vmware
 #monitor = Virtual-1, 1920x1080@60,auto,1
 
-# Hi Refresh Rate
+# High Refresh Rate
 #monitor=,highrr,auto,1
 
 # High Resolution
@@ -36,18 +31,21 @@ monitor=,preferred,auto,1
 # to disable a monitor
 #monitor=name,disable
 
-# Mirror
+# Mirror samples
 #monitor=DP-3,1920x1080@60,0x0,1,mirror,DP-2
 #monitor=,preferred,auto,1,mirror,eDP-1
-
-
-# Example :
-#monitor=eDP-1,2560x1440@165,0x0,1
-#workspace=HDMI-A-1,1
 #monitor=HDMI-A-1,2560x1440@144,0x0,1,mirror,eDP-1
-#workspace=HDMI-A-2,2
+
+# 10 bit monitor support - See wiki https://wiki.hyprland.org/Configuring/Monitors/#10-bit-support - See NOTES below
+# NOTE: Colors registered in Hyprland (e.g. the border color) do not support 10 bit.
+# NOTE: Some applications do not support screen capture with 10 bit enabled. (Screen captures like OBS may render black screen)
+# monitor=,preferred,auto,1,bitdepth,10
 
 #monitor=eDP-1,transform,0
 #monitor=eDP-1,addreserved,10,10,10,49
-#workspace=eDP-1,1
+
+# workspaces - Monitor rules
+# https://wiki.hyprland.org/Configuring/Workspace-Rules/
+# SUPER E - Workspace-Rules 
+# See ~/.config/hypr/UserConfigs/WorkspaceRules.conf
 


### PR DESCRIPTION
Add a note in Monitors.conf about 10 bit color displays and how it can affect screen captures

# Pull Request

## Description

Monitors that have a 10 bit color display  render a black screen when you try to share them. A simple fix to that is enabling the depthbit,10 option in the monitors config.

https://wiki.hyprland.org/Configuring/Monitors/#10-bit-support

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [x] **Other** (provide details below)

Configuration update

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.
