### PR TITLE
Weather.py bug fix (max/min temp mismatch)

### DIFF
--- a/config/hypr/UserScripts/Weather.py
+++ b/config/hypr/UserScripts/Weather.py
@@ -63,12 +63,12 @@ temp_feel_text = f"Feels like {temp_feel}c"
 # min-max temperature
 temp_min = (
     html_data("div[data-testid='wxData'] > span[data-testid='TemperatureValue']")
-    .eq(0)
+    .eq(1)
     .text()
 )
 temp_max = (
     html_data("div[data-testid='wxData'] > span[data-testid='TemperatureValue']")
-    .eq(1)
+    .eq(0)
     .text()
 )
 temp_min_max = f"  {temp_min}\t\t  {temp_max}"


### PR DESCRIPTION
# Pull Request

## Description

Fixed a bug that cause the inversion of temp_max and temp-min (by just changing a 1 and a 0).

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

# Screenshots

**With the bug**
![before](https://github.com/JaKooLit/Hyprland-Dots/assets/93724887/ca8318d1-0518-4d1b-b1ec-b83678d11d79)

**With the bug corrected**
![after](https://github.com/JaKooLit/Hyprland-Dots/assets/93724887/51137e82-890f-40cd-b675-30ce17e40a84)

**The correct values from the website**
![right_info](https://github.com/JaKooLit/Hyprland-Dots/assets/93724887/34d75754-d568-456b-8741-72c4e0d7d490)

I used a blue mark for the min, and red for the max. (Also I have no idea why the website isn't displaying a correct max temp, but that's another problem).
