### PR TITLE
fix: Enable hyprland animations by toggling gamemode off

### DIFF
--- a/config/hypr/scripts/GameMode.sh
+++ b/config/hypr/scripts/GameMode.sh
@@ -5,10 +5,9 @@
 notif="$HOME/.config/swaync/images/bell.png"
 SCRIPTSDIR="$HOME/.config/hypr/scripts"
 
-
 HYPRGAMEMODE=$(hyprctl getoption animations:enabled | awk 'NR==1{print $2}')
-if [ "$HYPRGAMEMODE" = 1 ] ; then
-    hyprctl --batch "\
+if [ "$HYPRGAMEMODE" = 1 ]; then
+  hyprctl --batch "\
         keyword animations:enabled 0;\
         keyword decoration:drop_shadow 0;\
         keyword decoration:blur:passes 0;\
@@ -16,16 +15,15 @@ if [ "$HYPRGAMEMODE" = 1 ] ; then
         keyword general:gaps_out 0;\
         keyword general:border_size 1;\
         keyword decoration:rounding 0"
-    swww kill 
-    notify-send -e -u low -i "$notif" "gamemode enabled. All animations off"
-    exit
+  swww kill
+  notify-send -e -u low -i "$notif" "gamemode enabled. All animations off"
+  exit
 else
-	swww-daemon --format xrgb && swww img "$HOME/.config/rofi/.current_wallpaper" &
-	sleep 0.1
-	${SCRIPTSDIR}/WallustSwww.sh
-	sleep 0.5
-	${SCRIPTSDIR}/Refresh.sh	 
-    notify-send -e -u normal -i "$notif" "gamemode disabled. All animations normal"
-    exit
+  swww-daemon --format xrgb && swww img "$HOME/.config/rofi/.current_wallpaper" &
+  sleep 0.1
+  ${SCRIPTSDIR}/WallustSwww.sh
+  sleep 0.5
+  ${SCRIPTSDIR}/Refresh.sh
+  notify-send -e -u normal -i "$notif" "gamemode disabled. All animations normal"
+  hyprctl reload
 fi
-hyprctl reload


### PR DESCRIPTION
# Pull Request

## Description

The Gamemode.sh file is unable to toggle on hyprland animations after turning it off

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

