### PR TITLE
fix: switch layout keyboard

### DIFF
--- a/config/hypr/scripts/SwitchKeyboardLayout.sh
+++ b/config/hypr/scripts/SwitchKeyboardLayout.sh
@@ -6,29 +6,41 @@ layout_f="$HOME/.cache/kb_layout"
 settings_file="$HOME/.config/hypr/UserConfigs/UserSettings.conf"
 notif="$HOME/.config/swaync/images/bell.png"
 
+echo "Starting script..."
+
 # Check if ~/.cache/kb_layout exists and create it with a default layout from Settings.conf if not found
 if [ ! -f "$layout_f" ]; then
+  echo "Creating layout file as it does not exist..."
   default_layout=$(grep 'kb_layout = ' "$settings_file" | cut -d '=' -f 2 | cut -d ',' -f 1 2>/dev/null)
   if [ -z "$default_layout" ]; then
     default_layout="us" # Default to 'us' layout if Settings.conf or 'kb_layout' is not found
   fi
   echo "$default_layout" > "$layout_f"
+  echo "Default layout set to $default_layout"
 fi
 
 current_layout=$(cat "$layout_f")
+echo "Current layout: $current_layout"
 
 # Read keyboard layout settings from Settings.conf
 if [ -f "$settings_file" ]; then
+  echo "Reading keyboard layout settings from $settings_file..."
   kb_layout_line=$(grep 'kb_layout = ' "$settings_file" | cut -d '=' -f 2)
   IFS=',' read -ra layout_mapping <<< "$kb_layout_line"
+  echo "Available layouts: ${layout_mapping[@]}"
+else
+  echo "Settings file not found!"
+  exit 1
 fi
 
 layout_count=${#layout_mapping[@]}
+echo "Number of layouts: $layout_count"
 
 # Find the index of the current layout in the mapping
 for ((i = 0; i < layout_count; i++)); do
   if [ "$current_layout" == "${layout_mapping[i]}" ]; then
     current_index=$i
+    echo "Current layout index: $current_index"
     break
   fi
 done
@@ -36,10 +48,7 @@ done
 # Calculate the index of the next layout
 next_index=$(( (current_index + 1) % layout_count ))
 new_layout="${layout_mapping[next_index]}"
-
-# Update the keyboard layout
-hyprctl switchxkblayout "at-translated-set-2-keyboard" "$new_layout"
-echo "$new_layout" > "$layout_f"
+echo "Next layout: $new_layout"
 
 # Created by T-Crypt
 
@@ -51,7 +60,8 @@ change_layout() {
     local got_error=false
 
     while read -r name; do
-        hyprctl switchxkblayout "$name" next
+        echo "Switching layout for $name to $new_layout..."
+        hyprctl switchxkblayout "$name" "$new_layout"
         if [[ $? -eq 0 ]]; then
             echo "Switched the layout for $name."
         else
@@ -74,5 +84,8 @@ if ! change_layout; then
     exit 1
 else
     # Notification for the new keyboard layout
-	  notify-send -u low -i "$notif" "new KB_Layout: $new_layout"
+    notify-send -u low -i "$notif" "new KB_Layout: $new_layout"
+    echo "Layout change notification sent."
 fi
+
+echo "$new_layout" > "$layout_f"


### PR DESCRIPTION
# Pull Request

## Description

Please read these instructions and remove unnecessary text.

- Try to include a summary of the changes and which issue is fixed.
- Also include relevant motivation and context (if applicable).
- List any dependencies that are required for this change. (e.g., packages or other PRs)
- Provide a link if there is an issue related to this pull request. e.g., Fixes # (issue)
- Please add Reviewers, Assignees, Labels, Projects, and Milestones to the PR. (if applicable)

## Type of change

Please put an `x` in the boxes that apply:

- [ x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [ x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [ x] My code follows the code style of this project.
- [x ] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

(if appropriate)

Issue: Keyboard Layout Switching Fails for Some Devices
Description
When attempting to switch keyboard layouts using the provided script, the command hyprctl switchxkblayout "at-translated-set-2-keyboard" "$new_layout" fails with the error device not found. This occurs because the specified device name does not match the actual device names in the system.

Steps to Reproduce
Use the provided script to switch keyboard layouts.
Observe the error message indicating that the device was not found.
Notice that the layout change only partially works for some devices.
Expected Behavior
The script should successfully switch the keyboard layout for all connected keyboard devices.

Actual Behavior
The script fails to switch the keyboard layout for the specified device at-translated-set-2-keyboard, but switches for other devices with different names.

This solution iterates over all connected keyboard devices and updates the layout for each one, ensuring that the layout switch works for all keyboards identified by hyprctl.

Add any other context about the problem here.
