### PR TITLE
fix: Make AGS respect monitor scale

### DIFF
--- a/config/ags/variables.js
+++ b/config/ags/variables.js
@@ -6,8 +6,8 @@ const { exec, execAsync } = Utils;
 Gtk.IconTheme.get_default().append_search_path(`${App.configDir}/assets/icons`);
 
 // Screen size
-export const SCREEN_WIDTH = Number(exec(`bash -c "hyprctl monitors -j | jq '.[0].width'"`));
-export const SCREEN_HEIGHT = Number(exec(`bash -c "hyprctl monitors -j | jq '.[0].height'"`));
+export const SCREEN_WIDTH = Number(exec(`bash -c "hyprctl monitors -j | jq '.[0].width / .[0].scale'"`));
+export const SCREEN_HEIGHT = Number(exec(`bash -c "hyprctl monitors -j | jq '.[0].height / .[0].scale'"`));
 
 // Mode switching
 export const currentShellMode = Variable('normal', {}) // normal, focus


### PR DESCRIPTION
# Pull Request

## Description

This PR makes `SCREEN_WIDTH` and `SCREEN_HEIGHT` take the scale of the monitor into account by dividing the resolution by the scale. The screenshots are with a 4k monitor with the monitor scale set to 2.0. (equals a final width and height of 1920x1080). The AGS overview scale is left at the default.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation. (Maybe?)
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes. (N/A?)
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed. (N/A?)

## Screenshots

| Before | After |
|--------|--------|
|  ![image](https://github.com/user-attachments/assets/b99170f1-19d7-4263-8537-523182bdcad5) | ![image](https://github.com/user-attachments/assets/f970be22-f9a9-46ff-b6a5-9c92e71026c5) |
