### PR TITLE
Screenshot notification improvement

### DIFF
--- a/config/hypr/scripts/ScreenShot.sh
+++ b/config/hypr/scripts/ScreenShot.sh
@@ -4,7 +4,6 @@
 
 iDIR="$HOME/.config/swaync/icons"
 sDIR="$HOME/.config/hypr/scripts"
-notify_cmd_shot="notify-send -h string:x-canonical-private-synchronous:shot-notify -u low -i ${iDIR}/picture.png"
 
 time=$(date "+%d-%b_%H-%M-%S")
 dir="$(xdg-user-dir)/Pictures/Screenshots"
@@ -14,23 +13,51 @@ active_window_class=$(hyprctl -j activewindow | jq -r '(.class)')
 active_window_file="Screenshot_${time}_${active_window_class}.png"
 active_window_path="${dir}/${active_window_file}"
 
+notify_cmd_base="notify-send -t 10000 -A action1=Open -A action2=Delete -h string:x-canonical-private-synchronous:shot-notify"
+notify_cmd_shot="${notify_cmd_base} -i ${dir}/${file}"
+notify_cmd_shot_win="${notify_cmd_base} -i ${active_window_path}"
+
 # notify and view screenshot
 notify_view() {
     if [[ "$1" == "active" ]]; then
         if [[ -e "${active_window_path}" ]]; then
-            ${notify_cmd_shot} "Screenshot of '${active_window_class}' Saved."
+            resp=$(${notify_cmd_shot_win} "Screenshot of '${active_window_class}' Saved.")
             "${sDIR}/Sounds.sh" --screenshot
+			case "$resp" in
+				action1)
+					xdg-open "${active_window_path}" &
+					;;
+				action2)
+					rm "${active_window_path}" &
+					;;
+			esac
         else
             ${notify_cmd_shot} "Screenshot of '${active_window_class}' not Saved"
             "${sDIR}/Sounds.sh" --error
         fi
     elif [[ "$1" == "swappy" ]]; then
-		${notify_cmd_shot} "Screenshot Captured."
+		resp=$(${notify_cmd_shot} "Screenshot Captured.")
+		case "$resp" in
+			action1)
+				xdg-open "${dir}/${file}" &
+				;;
+			action2)
+				rm "${dir}/${file}" &
+				;;
+		esac
     else
-        local check_file="$dir/$file"
+        local check_file="${dir}/${file}"
         if [[ -e "$check_file" ]]; then
-            ${notify_cmd_shot} "Screenshot Saved."
+            resp=$(timeout 10 ${notify_cmd_shot} "Screenshot Saved.")
             "${sDIR}/Sounds.sh" --screenshot
+			case "$resp" in
+				action1)
+					xdg-open "${check_file}" &
+					;;
+				action2)
+					rm "${check_file}" &
+					;;
+			esac
         else
             ${notify_cmd_shot} "Screenshot NOT Saved."
             "${sDIR}/Sounds.sh" --error
@@ -93,7 +120,7 @@ shotactive() {
 
     hyprctl -j activewindow | jq -r '"\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"' | grim -g - "${active_window_path}"
 	sleep 1
-    notify_view "active"  
+    notify_view "active"
 }
 
 shotswappy() {

--- a/config/hypr/scripts/ScreenShot.sh
+++ b/config/hypr/scripts/ScreenShot.sh
@@ -21,7 +21,7 @@ notify_cmd_shot_win="${notify_cmd_base} -i ${active_window_path}"
 notify_view() {
     if [[ "$1" == "active" ]]; then
         if [[ -e "${active_window_path}" ]]; then
-            resp=$(${notify_cmd_shot_win} "Screenshot of '${active_window_class}' Saved.")
+            resp=$(timeout 10 ${notify_cmd_shot_win} "Screenshot of '${active_window_class}' Saved.")
             "${sDIR}/Sounds.sh" --screenshot
 			case "$resp" in
 				action1)
@@ -36,7 +36,7 @@ notify_view() {
             "${sDIR}/Sounds.sh" --error
         fi
     elif [[ "$1" == "swappy" ]]; then
-		resp=$(${notify_cmd_shot} "Screenshot Captured.")
+		resp=$(timeout 10 ${notify_cmd_shot} "Screenshot Captured.")
 		case "$resp" in
 			action1)
 				xdg-open "${dir}/${file}" &


### PR DESCRIPTION
# Pull Request: Made some notification to screenshot script 

## Description
- Display captured screenshot in notification
- Open and delete button for the captured screenshot

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [x] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [x] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots
![image](https://github.com/user-attachments/assets/a4176552-7443-47aa-9b7f-3bdf7d6b9459)


## Additional context

Added timeout so that if user does not interact with the notification until the notification timeout, it does not wait in background for input `Open` or `Delete`
