### PR TITLE
Windowrules fixes and new 'negative:' option

### DIFF
--- a/config/hypr/UserConfigs/WindowRules.conf
+++ b/config/hypr/UserConfigs/WindowRules.conf
@@ -5,6 +5,9 @@
 #windowrule = noblur,gamescope
 #windowrule = fullscreen,gamescope
 #windowrule = workspace 6 silent,^(gamescope)$
+#windowrule = noblur,^(steam_app_\d+)$
+#windowrule = fullscreen,^(steam_app_\d+)$
+#windowrule = workspace 6,^(steam_app_\d+)$
 
 # windowrule Position
 windowrule = center,^(pavucontrol|org.pulseaudio.pavucontrol|com.saivert.pwvucontrol)
@@ -14,8 +17,7 @@ windowrule = center,^([Ff]erdium)$
 # WINDOWRULE v2
 # windowrule v2 - position
 # windowrulev2 = center,floating:1 # warning, it cause even the menu to float and center.
-windowrulev2 = center, class:([Tt]hunar), title:(File Operation Progress)
-windowrulev2 = center, class:([Tt]hunar), title:(Confirm to replace files)
+windowrulev2 = center, class:([Tt]hunar), title:negative:([Tt]hunar)
 windowrulev2 = center, title:^(ROG Control)$
 windowrulev2 = center, title:^(Keybindings)$  
 windowrulev2 = move 72% 7%,title:^(Picture-in-Picture)$ 
@@ -51,11 +53,10 @@ windowrulev2 = workspace 9 silent, class:^([Aa]udacious)$
 # windowrule v2 - float
 windowrulev2 = float, class:^(org.kde.polkit-kde-authentication-agent-1)$ 
 windowrulev2 = float, class:([Zz]oom|onedriver|onedriver-launcher)$
-windowrulev2 = float, class:([Tt]hunar), title:(File Operation Progress)
-windowrulev2 = float, class:([Tt]hunar), title:(Confirm to replace files)
+windowrulev2 = float, class:([Tt]hunar), title:negative:([Tt]hunar)
 windowrulev2 = float, class:(xdg-desktop-portal-gtk)
 windowrulev2 = float, class:(org.gnome.Calculator), title:(Calculator)
-windowrulev2 = float, class:(codium|codium-url-handler|VSCodium|code-oss), title:(Add Folder to Workspace)
+windowrulev2 = float, class:(codium|codium-url-handler|VSCodium|code-oss), title:negative:(codium|VSCodium)
 windowrulev2 = float, class:(electron), title:(Add Folder to Workspace)
 windowrulev2 = float, class:^([Rr]ofi)$
 windowrulev2 = float, class:^(eog|org.gnome.Loupe)$ # image viewer
@@ -70,7 +71,7 @@ windowrulev2 = float, class:^(evince)$ # document viewer
 windowrulev2 = float, class:^(file-roller|org.gnome.FileRoller)$ # archive manager
 windowrulev2 = float, class:^([Bb]aobab|org.gnome.[Bb]aobab)$ # Disk usage analyzer
 windowrulev2 = float, title:(Kvantum Manager)
-windowrulev2 = float, class:^([Ss]team)$,title:^((?![Ss]team).*|[Ss]team [Ss]ettings)$
+windowrulev2 = float, class:^([Ss]team)$,title:negative:^([Ss]team)$
 windowrulev2 = float, class:^([Qq]alculate-gtk)$
 #windowrulev2 = float, class:^([Ww]hatsapp-for-linux)$
 windowrulev2 = float, class:^([Ff]erdium)$

--- a/config/hypr/UserConfigs/WindowRules.conf
+++ b/config/hypr/UserConfigs/WindowRules.conf
@@ -17,7 +17,7 @@ windowrule = center,^([Ff]erdium)$
 # WINDOWRULE v2
 # windowrule v2 - position
 # windowrulev2 = center,floating:1 # warning, it cause even the menu to float and center.
-windowrulev2 = center, class:([Tt]hunar), title:negative:([Tt]hunar)
+windowrulev2 = center, class:([Tt]hunar), title:negative:(.*[Tt]hunar.*)
 windowrulev2 = center, title:^(ROG Control)$
 windowrulev2 = center, title:^(Keybindings)$  
 windowrulev2 = move 72% 7%,title:^(Picture-in-Picture)$ 
@@ -36,7 +36,7 @@ windowrulev2 = workspace 2, class:^([Ff]irefox|org.mozilla.firefox|[Ff]irefox-es
 windowrulev2 = workspace 2, class:^([Mm]icrosoft-edge(-stable|-beta|-dev|-unstable)?)$
 windowrulev2 = workspace 2, class:^([Gg]oogle-chrome(-beta|-dev|-unstable)?)$
 windowrulev2 = workspace 2, class:^([Tt]horium-browser|[Cc]achy-browser)$
-#windowrulev2 = workspace 3, class:^([Tt]hunar)$
+windowrulev2 = workspace 3, class:^([Tt]hunar)$
 windowrulev2 = workspace 4, class:^(com.obsproject.Studio)$
 windowrulev2 = workspace 5, class:^([Ss]team)$
 windowrulev2 = workspace 5, class:^([Ll]utris)$
@@ -53,10 +53,10 @@ windowrulev2 = workspace 9 silent, class:^([Aa]udacious)$
 # windowrule v2 - float
 windowrulev2 = float, class:^(org.kde.polkit-kde-authentication-agent-1)$ 
 windowrulev2 = float, class:([Zz]oom|onedriver|onedriver-launcher)$
-windowrulev2 = float, class:([Tt]hunar), title:negative:([Tt]hunar)
+windowrulev2 = float, class:([Tt]hunar), title:negative:(.*[Tt]hunar.*)
 windowrulev2 = float, class:(xdg-desktop-portal-gtk)
 windowrulev2 = float, class:(org.gnome.Calculator), title:(Calculator)
-windowrulev2 = float, class:(codium|codium-url-handler|VSCodium|code-oss), title:negative:(codium|VSCodium)
+windowrulev2 = float, class:(codium|codium-url-handler|VSCodium|code-oss), title:negative:(.*codium.*|.*VSCodium.*)
 windowrulev2 = float, class:(electron), title:(Add Folder to Workspace)
 windowrulev2 = float, class:^([Rr]ofi)$
 windowrulev2 = float, class:^(eog|org.gnome.Loupe)$ # image viewer


### PR DESCRIPTION
# Pull Request

## Description

Cleaned up some popups/dialogue boxes floating and added generic popup/dialogue boxes floating support for a few apps using the new 'negative:' regex option in Hyprland V0.47.0.
Fixed Steam friends list/preference being tiled, which was broken sometime in V0.46.x.
Also added support for Steam games to go to workspace 6, fullscreen and disable blur if you don't use Gamescope

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

(if appropriate)

## Additional context

Its been a while I hope i did this correctly :P
I have also messed around with tags to steamline some of the window rule, eg: having a tag 'browser' so all web browser options are the same and grouped, if your interested.