### PR TITLE
Update Keybinds.conf swap windows

### DIFF
--- a/config/hypr/configs/Keybinds.conf
+++ b/config/hypr/configs/Keybinds.conf
@@ -76,6 +76,12 @@ bind = $mainMod CTRL, right, movewindow, r
 bind = $mainMod CTRL, up, movewindow, u
 bind = $mainMod CTRL, down, movewindow, d
 
+# Swap windows
+bind = $mainMod ALT, left, swapwindow, l
+bind = $mainMod ALT, right, swapwindow, r
+bind = $mainMod ALT, up, swapwindow, u
+bind = $mainMod ALT, down, swapwindow, d
+
 # Move focus with mainMod + arrow keys
 bind = $mainMod, left, movefocus, l
 bind = $mainMod, right, movefocus, r


### PR DESCRIPTION
Using MOD + ALT + Arrow keys to swap tiled windows L/R and U/D  Makes it very easy and fast to move tiled windows around

# Pull Request

## Description
it's a keybind I used to have and when I found it again I found it very useful. 

## Type of change

Please put an `x` in the boxes that apply:

- [X] **New feature** (non-breaking change which adds functionality)
- [X] **Documentation update** (non-breaking change; modified files are limited to the documentations)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [X] My change requires a change to the documentation.
- [X] I have tested my code locally and it works as expected.

## Screenshots
