### PR TITLE
fix: full binary path for pyprland init

### DIFF
--- a/config/hypr/UserConfigs/Startup_Apps.conf
+++ b/config/hypr/UserConfigs/Startup_Apps.conf
@@ -38,7 +38,7 @@ exec-once = $UserScripts/RainbowBorders.sh &
 exec-once = hypridle &
 
 # Start pyprland daemon
-exec-once = pypr &
+exec-once = /usr/bin/pypr &
 
 # Here are list of features available but disabled by default
 # exec-once = swww-daemon --format xrgb && swww img $HOME/Pictures/wallpapers/mecha-nostalgia.png  # persistent wallpaper


### PR DESCRIPTION
# Pull Request

## Description

I had some issues with pyprland init, and I found out that writing the full path of the binary instead of pypr fixes this (as it is described in [pyprland docs](https://hyprland-community.github.io/pyprland/Getting-started.html#running))

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x ] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [ x] My code follows the code style of this project.
- [x ] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [ x] I have tested my code locally and it works as expected.
- [ x] All new and existing tests passed.

