### PR TITLE
fix: updated waybar to recognize zen-browser and steam

### DIFF
--- a/config/waybar/ModulesWorkspaces
+++ b/config/waybar/ModulesWorkspaces
@@ -210,7 +210,7 @@
 		"class<com.obsproject.Studio>": " ",
 		"class<polkit-gnome-authentication-agent-1>": "󰒃 ",
 		"class<nwg-look>": " ",
-		"class<zen-alpha>": "󰰷 ", //Zen Browser
+		"class<zen>": "󰰷 ", //Zen Browser
 		"class<waterfox|waterfox-bin>": " ",
 		"class<microsoft-edge>": " ",
 		"class<vlc>": "󰕼 "

--- a/config/waybar/ModulesWorkspaces
+++ b/config/waybar/ModulesWorkspaces
@@ -213,7 +213,8 @@
 		"class<zen>": "󰰷 ", //Zen Browser
 		"class<waterfox|waterfox-bin>": " ",
 		"class<microsoft-edge>": " ",
-		"class<vlc>": "󰕼 "
+		"class<vlc>": "󰕼 ",
+		"class<steam>": " "
 		}   
 	},
 


### PR DESCRIPTION
# Pull Request

## Description

Originally in NUMBERS and ICONS style with window rewrite, zen browser would not be recognized and would show the default question mark. This change made it display properly. Additionally, the steam class was added, using the icon from the NUMBERS and ICONS style.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.