### PR TITLE
Update WaybarCava.sh set framerate to 30

### DIFF
--- a/config/hypr/scripts/WaybarCava.sh
+++ b/config/hypr/scripts/WaybarCava.sh
@@ -18,6 +18,10 @@ done
 config_file="/tmp/bar_cava_config"
 cat >"$config_file" <<EOF
 [general]
+# Older systems show significant CPU use with default framerate
+# Setting maximum framerate to 30  
+# You can increase the value if you wish
+framerate = 30
 bars = 10
 
 [input]


### PR DESCRIPTION

# Pull Request

## Description

 Older CPU systems show significant CPU use with the default framerate value.  This patch sets it to 30.  The CPU load is less but it still is responsive on the waybar.  Added text in file to explain this and that it can be increased if they wish

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Documentation update** (non-breaking change; modified files are limited to the documentations)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [X ] My change requires a change to the documentation.
- [X] I have tested my code locally and it works as expected.

 
