### PR TITLE
Update Keybinds.conf  fix ALT-TAB

### DIFF
--- a/config/hypr/configs/Keybinds.conf
+++ b/config/hypr/configs/Keybinds.conf
@@ -35,8 +35,8 @@ bind = $mainMod, G, togglegroup # toggle group
 bind = $mainMod CTRL, tab, changegroupactive  # change focus to another window
 
  # Cycle windows if floating bring to top
-bind = ALT, tab, cyclenext
-bind = ALT, tab, bringactivetotop  
+binde = ALT, tab, cyclenext
+binde = ALT, tab, bringactivetotop  
 
 # Special Keys / Hot Keys
 bindel = , xf86audioraisevolume, exec, $scriptsDir/Volume.sh --inc # volume up


### PR DESCRIPTION
it should be 
binde = ALT, Tab, cyclenext
binde = ALT, Tab,  bringactivetotop

I had to fix this is ZaneyOS and submitted to ML4W also.  Otherwise depending on HL version it may not act consistently.
I.e. with just two tiled windows it will not stay on the other tile, it will return focus to starting window.  With floating windows it will only toggle between two windows if you have more than two.   This resolves that 

# Pull Request

## Description
 
## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [X] I have tested my code locally and it works as expected.


## Screenshots

(if appropriate)

## Additional context

Add any other context about the problem here.
