### PR TITLE
Update copy.sh  Time format desc wrong

### DIFF
--- a/copy.sh
+++ b/copy.sh
@@ -344,7 +344,7 @@ printf "\n%.0s" {1..1}
 # Ask whether to change to 12hr format
 while true; do
     echo -e "${NOTE} ${SKY_BLUE} By default, KooL's Dots are configured in 24H clock format."
-    read -p "$CAT Do you want to change to 24H or AM/PM format? (y/n): " answer
+    read -p "$CAT Do you want to change to 12H (AM/PM) clock format? (y/n): " answer
 
     # Convert the answer to lowercase for comparison
     answer=$(echo "$answer" | tr '[:upper:]' '[:lower:]')

--- a/copy.sh
+++ b/copy.sh
@@ -344,7 +344,7 @@ printf "\n%.0s" {1..1}
 # Ask whether to change to 12hr format
 while true; do
     echo -e "${NOTE} ${SKY_BLUE} By default, KooL's Dots are configured in 24H clock format."
-    read -p "$CAT Do you want to change to 12H format or AM/PM format? (y/n): " answer
+    read -p "$CAT Do you want to change to 24H or AM/PM format? (y/n): " answer
 
     # Convert the answer to lowercase for comparison
     answer=$(echo "$answer" | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
# Pull Request

## Description
Setting time format to military time  or AM/PM asked if you wanted 12hr or AM/PM which are the same.  Corrected text to `24HR or AM/PM`
 

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
