### PR TITLE
fix: Fix ScreenShot.sh to check xdg-user-dir PICTURES

### DIFF
--- a/config/hypr/scripts/ScreenShot.sh
+++ b/config/hypr/scripts/ScreenShot.sh
@@ -4,7 +4,7 @@
 
 # variables
 time=$(date "+%d-%b_%H-%M-%S")
-dir="$(xdg-user-dir)/Pictures/Screenshots"
+dir="$(xdg-user-dir PICTURES)/Screenshots"
 file="Screenshot_${time}_${RANDOM}.png"
 
 iDIR="$HOME/.config/swaync/icons"


### PR DESCRIPTION
# Pull Request

## Description

Issue Link: [#679](https://github.com/JaKooLit/Hyprland-Dots/issues/679)

I have the Pictures folder not in `/home/<user>/Pictures` but in a different drive. You can set this up in `~/.config/user-dirs.dirs` and update it with `xdg-user-dirs-update`.

The issue is that the way the dir variable in `ScreenShot.sh` is setup it'll ignore the user's configured Picture's folder in xdg-user-dir and send the screenshots to their home directory (`/home/<user>/Pictures/Screenshots`).

Removing `/Pictures` from the concat and passing `PICTURES` as an argument to `xdg-user-dir` fixes this and the screenshots will be sent to the correct Pictures folder, be it in the home directory or any custom path.

This is the change I propose for `config/hypr/scripts/ScreenShot.sh`, I've tested it and works fine:

``` bash
# Old:
dir="$(xdg-user-dir)/Pictures/Screenshots"
# New:
dir="$(xdg-user-dir PICTURES)/Screenshots"
```

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
