### PR TITLE
fix: Prevent execution of directories in Polkit.sh

### DIFF
--- a/config/hypr/scripts/Polkit.sh
+++ b/config/hypr/scripts/Polkit.sh
@@ -7,6 +7,7 @@ polkit=(
   "/usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1"
   "/usr/libexec/hyprpolkitagent"
   "/usr/lib/hyprpolkitagent"
+  "/usr/lib/hyprpolkitagent/hyprpolkitagent"
   "/usr/lib/polkit-kde-authentication-agent-1"
   "/usr/lib/polkit-gnome-authentication-agent-1"
   "/usr/libexec/polkit-gnome-authentication-agent-1"
@@ -15,13 +16,13 @@ polkit=(
   "/usr/lib/policykit-1-gnome/polkit-gnome-authentication-agent-1"
 )
 
-executed=false  # Flag to track if a file has been executed
+executed=false # Flag to track if a file has been executed
 
 # Loop through the list of files
 for file in "${polkit[@]}"; do
-  if [ -e "$file" ]; then
+  if [ -e "$file" ] && [ -f "$file" ] && [ -x "$file" ]; then
     echo "File $file found, executing command..."
-    exec "$file"  
+    exec "$file"
     executed=true
     break
   fi


### PR DESCRIPTION
# Pull Request

## Description

The script was attempting to execute directories if they matched a path in the polkit array. This fix ensures that only existing regular files with executable permissions are executed.

This resolves an error where the script would fail with: "line 24: /usr/lib/hyprpolkitagent: cannot execute: Is a directory"

if [ -e "$file" ] && [ -f "$file" ] && [ -x "$file" ]; then
This line of code makes sure the path is not an directory but a regular file and it is excutable. 

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.


## Additional context


Please let me know if I can improve the PR in any way, Thank you.