### PR TITLE
Update UserSettings.conf   -- Extend ANR timeout  -- Disable donation reminders 

### DIFF
--- a/config/hypr/UserConfigs/UserSettings.conf
+++ b/config/hypr/UserConfigs/UserSettings.conf
@@ -134,6 +134,9 @@ misc {
   focus_on_activate = false
   swallow_regex = ^(kitty)$
   #disable_autoreload = true
+  # Application Not Responding settings (ANR)
+  enable_anr_dialog = true
+  anr_missed_pings = 20   # default is 1 - way too short
 }
 
 binds {
@@ -151,3 +154,10 @@ xwayland {
 #cursor {
 #	enable_hyprcursor = true
 #}
+
+# ### Update confirmation / Donation Reminders 
+
+ecosystem {
+ no_donation_nag = true
+    no_update_news = false
+  }


### PR DESCRIPTION
Added settings for ANR 
Disabled donation reminder

# Pull Request

## Description
 New feature Application Not Responding (ANR) was added in v0.48
 This patch formally enables it but more importantly sets the # of pings higher than the default of 1
The default is so short python scripts and copy/paste operations were triggering it  I set the starting value to 20 

 2nd change is also post v0.49  Hyprland now has repeating requests for donations 

 The "ecosystem"  option enables / disables that. 

 There are two parts, notification of major update, (confirmation)  and the request for donations. 
 My change keeps the former, and disables direct requests for donations 

## Type of change

Please put an `x` in the boxes that apply:

 
- [x] **New feature** (non-breaking change which adds functionality)
- [X] **Documentation update** (non-breaking change; modified files are limited to the documentations)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [X] My change requires a change to the documentation.
- [X] I have tested my code locally and it works as expected.
 
## Screenshots

(if appropriate)

## Additional context

Add any other context about the problem here.
