### PR TITLE
Update UserSettings.conf anr settings no reminders

### DIFF
--- a/config/hypr/UserConfigs/UserSettings.conf
+++ b/config/hypr/UserConfigs/UserSettings.conf
@@ -85,6 +85,9 @@ misc {
   focus_on_activate = false
   initial_workspace_tracking = 0
   middle_click_paste = false
+  # Application Not Responding (ANR) settings
+  enable_anr_dialog = true 
+  anr_missed_pings = 20
 }
 
 #opengl {
@@ -115,4 +118,9 @@ cursor {
   enable_hyprcursor = true
   warp_on_change_workspace = 2
   no_warps = true 
+}
+
+ecosystem { 
+ no_update_news = false 
+ no_donation_nag = true
 }


### PR DESCRIPTION
Set threshold for ANR default is 1 missed ping which is way too short.  Also disabled donation reminder alerts

# Pull Request

## Description
  Hyprland v0.48+ added Application Not Responding service (ANR) 
 The default threshold of one (1) missed ping is too short.  Running python apps (like waypaper) and copy / paste operations would trigger the alert.  Set the level to 20 as a starting point 

 Also added in v0.49 were donation reminder messages in addtion to a flash screen after upgrading 
I disabled the donation reminder but kept the update banner.  That too can be disabled 
 

## Type of change

Please put an `x` in the boxes that apply:

 
- [X] **New feature** (non-breaking change which adds functionality)
- [X] **Documentation update** (non-breaking change; modified files are limited to the documentations)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [X] My change requires a change to the documentation.
- [X] I have tested my code locally and it works as expected.
  

