### PR TITLE
feat: Display battery level and power status on lock screen

### DIFF
--- a/config/hypr/hyprlock.conf
+++ b/config/hypr/hyprlock.conf
@@ -156,6 +156,18 @@ label {
     valign = bottom
 }
 
+# battery
+label {
+    monitor =
+    text = cmd[update:1000] echo "<b> "$($Scripts/Power.sh)" </b>"
+    color = $color13
+    font_size = 18
+    font_family = Victor Mono Bold Oblique
+    position = 0, 30
+    halign = right
+    valign = bottom
+}
+
 # weather edit the scripts for locations
 # weather scripts are located in ~/.config/hypr/UserScripts Weather.sh and/or Weather.py
 # see https://github.com/JaKooLit/Hyprland-Dots/wiki/TIPS#%EF%B8%8F-weather-app-related-for-waybar-and-hyprlock

--- a/config/hypr/scripts/Power.sh
+++ b/config/hypr/scripts/Power.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+for i in {0..3}; do
+  if [ -f /sys/class/power_supply/BAT$i/capacity ]; then
+    battery_level=$(cat /sys/class/power_supply/BAT$i/status)
+    battery_capacity=$(cat /sys/class/power_supply/BAT$i/capacity)
+    echo "Power: $battery_capacity% ($battery_level)"
+  fi
+done


### PR DESCRIPTION
# Pull Request

## Description

This PR introduces a **new feature** to Hyprlock that displays battery information (percentage and status) in the bottom right section of the lock screen.

-   **Power.sh** is a script that fetches the current battery level and status.
    
-   **hyprlock.conf** has been modified to include and display this data visually on the lock screen.
    

This change enhances usability for laptop users, allowing them to monitor power status without unlocking their device.

### Dependencies

-   No external dependencies.
-   Relies on standard Linux power management interfaces (`/sys/class/power_supply/`).

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots
![IMG_20250522_112233](https://github.com/user-attachments/assets/725c5546-72ef-4213-817a-fc371569d210)


## Additional context

-   Script added: `config/hypr/scripts/Power.sh`
    
-   Modified: `config/hypr/hyprlock.conf`

This is part of an effort to improve UX for portable device users. This feature allows laptop users to view power info when their device is locked, especially useful when the device is discharging.
