### PR TITLE
Remove trailing whitespace from WindowRules.conf

### DIFF
--- a/config/hypr/UserConfigs/WindowRules.conf
+++ b/config/hypr/UserConfigs/WindowRules.conf
@@ -44,7 +44,7 @@ windowrule = tag +screenshare, class:^(com.obsproject.Studio)$
 windowrule = tag +im, class:^([Dd]iscord|[Ww]ebCord|[Vv]esktop)$
 windowrule = tag +im, class:^([Ff]erdium)$
 windowrule = tag +im, class:^([Ww]hatsapp-for-linux)$
-windowrule = tag +im, class:^(ZapZap|com.rtosta.zapzap)$ 
+windowrule = tag +im, class:^(ZapZap|com.rtosta.zapzap)$
 windowrule = tag +im, class:^(org.telegram.desktop|io.github.tdesktop_x64.TDesktop)$
 windowrule = tag +im, class:^(teams-for-linux)$
 


### PR DESCRIPTION
# Pull Request

## Description

Noticed a trailing whitespace on line 47 in the latest WindowRules.conf 

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [X] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [X] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

