### PR TITLE
Render unfocused games when workspace goes inactive

### DIFF
--- a/config/hypr/UserConfigs/WindowRules.conf
+++ b/config/hypr/UserConfigs/WindowRules.conf
@@ -197,6 +197,7 @@ windowrule = pin, title:^(Picture-in-Picture)$
 
 # windowrule - extras
 windowrule = keepaspectratio, title:^(Picture-in-Picture)$
+windowrule = renderunfocused, tag:games
 
 # BLUR & FULLSCREEN
 windowrule = noblur, tag:games*


### PR DESCRIPTION
feat: render unfocused games when workspace goes inactive
# Pull Request

## Description

This commit adds a small change to the WindowRules.conf that makes it so any application tagged as games will always render at least 15 frames per second when the workspace is inactive. This solves potential problems where games that are "alt-tabbed" can crash or hang. This is especially a problem when hosting a multiplayer session with friends.

More information can be found here in the Hyprland docs: https://wiki.hyprland.org/Configuring/Window-Rules/
As well as this discussion thread: https://github.com/hyprwm/Hyprland/pull/7582

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [X] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
