### PR TITLE
Expose font size and family in config

### DIFF
--- a/config/quickshell/config.json
+++ b/config/quickshell/config.json
@@ -15,7 +15,8 @@
     "numOfCols": 5,
     "showXwaylandIndicator": true,
     "windowPadding": 6,
-    "position": 1
+    "position": 1,
+    "workspaceNumberSize": 220
   },
   "resources": {
     "updateInterval": 3000
@@ -34,5 +35,26 @@
   },
   "bar": {
     "bottom": false
+  },
+  "font": {
+    "family": {
+      "main": "Open Sans",
+      "title": "JetBrains Mono NF",
+      "iconMaterial": "FiraConde Nerd Font",
+      "iconNerd": "SpaceMono NF",
+      "monospace": "JetBrains Mono NF",
+      "reading": "Readex Pro"
+    },
+    "pixelSize": {
+      "smallest": 10,
+      "smaller": 13,
+      "small": 15,
+      "normal": 16,
+      "large": 17,
+      "larger": 19,
+      "huge": 22,
+      "hugeass": 23,
+      "title": 28
+    }
   }
 }

--- a/config/quickshell/modules/common/ConfigOptions.qml
+++ b/config/quickshell/modules/common/ConfigOptions.qml
@@ -16,6 +16,7 @@ Singleton {
         property bool showXwaylandIndicator: true
         property real windowPadding: 6 
         property real position: 1 // 0: top | 1: middle | 2: bottom
+        property real workspaceNumberSize: 120 // Set 0, dynamic calculation based on monitor size
     }
 
     property QtObject resources: QtObject {

--- a/config/quickshell/modules/overview/OverviewWidget.qml
+++ b/config/quickshell/modules/overview/OverviewWidget.qml
@@ -35,7 +35,9 @@ Item {
         ((monitor.height - monitorData?.reserved[1] - monitorData?.reserved[3]) * root.scale / monitor.scale))
 
     property real workspaceNumberMargin: 80
-    property real workspaceNumberSize: Math.min(workspaceImplicitHeight, workspaceImplicitWidth) * monitor.scale
+    property real workspaceNumberSize: (ConfigOptions.overview.workspaceNumberSize > 0) 
+        ? ConfigOptions.overview.workspaceNumberSize 
+        : Math.min(workspaceImplicitHeight, workspaceImplicitWidth) * monitor.scale
     property int workspaceZ: 0
     property int windowZ: 1
     property int windowDraggingZ: 99999


### PR DESCRIPTION
# Pull Request

## Description
Added font configuration support to the shell configuration system, allowing users to customize font families and sizes through `config.json`. The configuration loader now separates font settings from other config options and applies them to the `Appearance` object instead of `ConfigOptions`.

**Changes:**
* Modified `ConfigLoader.qml` to handle a new `font` section in `config.json`
* Font configuration is now applied to `Appearance.font` while other configs go to `ConfigOptions` as usual
* Added support for both `family` and `pixelSize` font properties
* Maintains backward compatibility - if no font section exists, default values are preserved

**Configuration structure:**

```json
{
  "font": {
    "family": {
      "main": "Open Sans",
      "title": "JetBrains Mono NF",
      "iconMaterial": "FiraConde Nerd Font",
      "iconNerd": "SpaceMono NF",
      "monospace": "JetBrains Mono NF",
      "reading": "Readex Pro"
    },
    "pixelSize": {
      "smallest": 10,
      "smaller": 13,
      "small": 15,
      "normal": 16,
      "large": 17,
      "larger": 19,
      "huge": 22,
      "hugeass": 23,
      "title": 28
    }
  }
}
```

**Note:** Since these font names are generic, you'll need to experiment with different sizes to see what they affect, or look through the QML files to understand their usage. I know it's not ideal, but hot reload helps! 😅 Will try to rename them to something more intuitive in the future (which is boring and a lot of work right now).

## Type of change
Please put an `x` in the boxes that apply:
* [ ] **Bug fix** (non-breaking change which fixes an issue)
* [x] **New feature** (non-breaking change which adds functionality)
* [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
* [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
* [x] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
* [ ] **Other** (provide details below)

## Checklist
Please put an `x` in the boxes that apply:
* [x] I have read the CONTRIBUTING document.
* [x] My code follows the code style of this project.
* [x] My commit message follows the commit guidelines.
* [ ] My change requires a change to the documentation.
* [ ] I want to add something in Hyprland-Dots wiki.
* [ ] I have added tests to cover my changes.
* [x] I have tested my code locally and it works as expected.
* [x] All new and existing tests passed.

## Additional context
This enhancement allows users to customize fonts without diving into QML files. The implementation preserves existing default values when font configuration is not provided, ensuring no breaking changes for existing setups.

The font configuration is hot-reloadable, so users can experiment with different fonts and sizes and see changes immediately without restarting the shell.