### PR TITLE
Improve copy.sh script

### DIFF
--- a/copy.sh
+++ b/copy.sh
@@ -75,11 +75,6 @@ if [ ! -d Copy-Logs ]; then
     mkdir Copy-Logs
 fi
 
-# Function to print colorful text
-print_color() {
-    printf "%b%s%b\n" "$1" "$2" "$CLEAR"
-}
-
 # Set the name of the log file to include the current date and time
 LOG="Copy-Logs/install-$(date +%d-%H%M%S)_dotfiles.log"
 

--- a/copy.sh
+++ b/copy.sh
@@ -33,7 +33,7 @@ fi
 
 # Function to print colorful text
 print_color() {
-    printf "%b%s%b\n" "$1" "$2" "$CLEAR"
+    printf "%b%s%b\n" "$1" "$2" "$RESET"
 }
 
 # Check /etc/os-release to see if this is an Ubuntu or Debian based distro


### PR DESCRIPTION
# Pull Request

## Description

This pull request improves the `print_color` function in two ways.

First, the variable `CLEAR` is renamed to `RESET`. This change
improves semantic clarity, as the variable's purpose is to reset
terminal text formatting, not just clear it.

Second, a redundant, duplicate definition of the `print_color`
function is removed to clean up the code and improve maintainability.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have tested my code locally and it works as expected.
