### PR TITLE
Fix: Fix qs alignment scale

### DIFF
--- a/config/quickshell/modules/overview/OverviewWidget.qml
+++ b/config/quickshell/modules/overview/OverviewWidget.qml
@@ -239,8 +239,8 @@ Item {
                 delegate: OverviewWindow {
                     id: window
                     windowData: windowByAddress[modelData]
-                    monitorData: root.monitorData
-                    scale: root.scale
+                    monitorData: HyprlandData.monitors.find(m => m.id === windowData?.monitor) // use monitorData of the monitor the window is on
+                    scale: root.scale * (monitorData?.scale / root.monitor?.scale) // adjust window scale to the monitor where the overview is displayed
                     availableWorkspaceWidth: root.workspaceImplicitWidth
                     availableWorkspaceHeight: root.workspaceImplicitHeight
 


### PR DESCRIPTION
# Pull Request

## Description
Fixes two issues with windows in the quickshell overview if they are not on the same monitor as the overview:
1) Windows now use the monitor they are on instead of the monitor of the quickshell overview for their positioning.
2) Window scale is now adjusted to fit the scale of the monitor where the overview is displayed. Previously windows which were on a monitor that has a different scale as the monitor where the overview is displayed, were either too big or too small. 

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Additional context

Fixing another set of window issues with the new quickshell overview that poped up after #779 .
Thanks to @JaKooLit for helping with testing when i only had one monitor.
