### PR TITLE
Fix for Dropdown Terminal Monitor Scaling

### DIFF
--- a/config/hypr/scripts/Dropterminal.sh
+++ b/config/hypr/scripts/Dropterminal.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # /* ---- 💫 https://github.com/JaKooLit 💫 ---- */  ##
+#
+# Made and brought to by Kiran George
+# /* -- ✨ https://github.com/SherLock707 ✨ -- */  ##
 # Dropdown Terminal 
 # Usage: ./Dropdown.sh [-d] <terminal_command>
 # Example: ./Dropdown.sh foot

--- a/config/hypr/scripts/Dropterminal.sh
+++ b/config/hypr/scripts/Dropterminal.sh
@@ -14,8 +14,7 @@ ADDR_FILE="/tmp/dropdown_terminal_addr"
 # Dropdown size and position configuration (percentages)
 WIDTH_PERCENT=50  # Width as percentage of screen width
 HEIGHT_PERCENT=50 # Height as percentage of screen height
-X_PERCENT=25      # X position as percentage from left (25% centers a 50% width window)
-Y_PERCENT=5       # Y position as percentage from top
+Y_PERCENT=5       # Y position as percentage from top (X is auto-centered)
 
 # Animation settings
 ANIMATION_DURATION=100  # milliseconds
@@ -49,8 +48,8 @@ if [ -z "$TERMINAL_CMD" ]; then
     echo "Edit the script to modify size and position:"
     echo "  WIDTH_PERCENT  - Width as percentage of screen (default: 50)"
     echo "  HEIGHT_PERCENT - Height as percentage of screen (default: 50)"
-    echo "  X_PERCENT      - X position from left as percentage (default: 25)"
     echo "  Y_PERCENT      - Y position from top as percentage (default: 5)"
+    echo "  Note: X position is automatically centered"
     exit 1
 fi
 
@@ -117,26 +116,83 @@ animate_slide_up() {
     debug_echo "Slide up animation completed"
 }
 
-# Function to get monitor info for centering
+# Function to get monitor info including scale
 get_monitor_info() {
-    hyprctl monitors -j | jq -r '.[0] | "\(.x) \(.y) \(.width) \(.height)"'
+    local monitor_data=$(hyprctl monitors -j | jq -r '.[0] | "\(.x) \(.y) \(.width) \(.height) \(.scale)"')
+    
+    if [ -z "$monitor_data" ] || [ "$monitor_data" = "null null null null null" ]; then
+        debug_echo "Error: Could not get monitor information"
+        return 1
+    fi
+    
+    echo "$monitor_data"
 }
 
-# Function to calculate dropdown position
+# Function to calculate dropdown position with proper scaling and centering
 calculate_dropdown_position() {
     local monitor_info=$(get_monitor_info)
+    
+    if [ $? -ne 0 ] || [ -z "$monitor_info" ]; then
+        debug_echo "Error: Failed to get monitor info, using fallback values"
+        echo "100 100 800 600"
+        return 1
+    fi
+    
     local mon_x=$(echo $monitor_info | cut -d' ' -f1)
     local mon_y=$(echo $monitor_info | cut -d' ' -f2)
     local mon_width=$(echo $monitor_info | cut -d' ' -f3)
     local mon_height=$(echo $monitor_info | cut -d' ' -f4)
+    local mon_scale=$(echo $monitor_info | cut -d' ' -f5)
     
-    # Calculate position and size based on percentages
-    local width=$((mon_width * WIDTH_PERCENT / 100))
-    local height=$((mon_height * HEIGHT_PERCENT / 100))
-    local x=$((mon_x + (mon_width * X_PERCENT / 100)))
-    local y=$((mon_y + (mon_height * Y_PERCENT / 100)))
+    debug_echo "Monitor info: x=$mon_x, y=$mon_y, width=$mon_width, height=$mon_height, scale=$mon_scale"
     
-    echo "$x $y $width $height"
+    # Validate scale value and provide fallback
+    if [ -z "$mon_scale" ] || [ "$mon_scale" = "null" ] || [ "$mon_scale" = "0" ]; then
+        debug_echo "Invalid scale value, using 1.0 as fallback"
+        mon_scale="1.0"
+    fi
+    
+    # Calculate logical dimensions by dividing physical dimensions by scale
+    local logical_width logical_height
+    if command -v bc >/dev/null 2>&1; then
+        # Use bc for precise floating point calculation
+        logical_width=$(echo "scale=0; $mon_width / $mon_scale" | bc | cut -d'.' -f1)
+        logical_height=$(echo "scale=0; $mon_height / $mon_scale" | bc | cut -d'.' -f1)
+    else
+        # Fallback to integer math (multiply by 100 for precision, then divide)
+        local scale_int=$(echo "$mon_scale" | sed 's/\.//' | sed 's/^0*//')
+        if [ -z "$scale_int" ]; then scale_int=100; fi
+        
+        logical_width=$(((mon_width * 100) / scale_int))
+        logical_height=$(((mon_height * 100) / scale_int))
+    fi
+    
+    # Ensure we have valid integer values
+    if ! [[ "$logical_width" =~ ^-?[0-9]+$ ]]; then logical_width=$mon_width; fi
+    if ! [[ "$logical_height" =~ ^-?[0-9]+$ ]]; then logical_height=$mon_height; fi
+    
+    debug_echo "Physical resolution: ${mon_width}x${mon_height}"
+    debug_echo "Logical resolution: ${logical_width}x${logical_height} (physical ÷ scale)"
+    
+    # Calculate window dimensions based on LOGICAL space percentages
+    local width=$((logical_width * WIDTH_PERCENT / 100))
+    local height=$((logical_height * HEIGHT_PERCENT / 100))
+    
+    # Calculate Y position from top based on percentage of LOGICAL height
+    local y_offset=$((logical_height * Y_PERCENT / 100))
+    
+    # Calculate centered X position in LOGICAL space
+    local x_offset=$(((logical_width - width) / 2))
+    
+    # Apply monitor offset to get final positions in logical coordinates
+    local final_x=$((mon_x + x_offset))
+    local final_y=$((mon_y + y_offset))
+    
+    debug_echo "Window size: ${width}x${height} (logical pixels)"
+    debug_echo "Final position: x=$final_x, y=$final_y (logical coordinates)"
+    debug_echo "Hyprland will scale these to physical coordinates automatically"
+    
+    echo "$final_x $final_y $width $height"
 }
 
 # Get the current workspace
@@ -174,17 +230,21 @@ spawn_terminal() {
     debug_echo "Creating new dropdown terminal with command: $TERMINAL_CMD"
     
     # Calculate dropdown position for later use
-    pos_info=$(calculate_dropdown_position)
-    target_x=$(echo $pos_info | cut -d' ' -f1)
-    target_y=$(echo $pos_info | cut -d' ' -f2)
-    width=$(echo $pos_info | cut -d' ' -f3)
-    height=$(echo $pos_info | cut -d' ' -f4)
+    local pos_info=$(calculate_dropdown_position)
+    if [ $? -ne 0 ]; then
+        debug_echo "Warning: Using fallback positioning"
+    fi
     
-    debug_echo "Target position: ${target_x}x${target_y}, size: ${width}x${height}"
+    local target_x=$(echo $pos_info | cut -d' ' -f1)
+    local target_y=$(echo $pos_info | cut -d' ' -f2)
+    local width=$(echo $pos_info | cut -d' ' -f3)
+    local height=$(echo $pos_info | cut -d' ' -f4)
+    
+    debug_echo "Target position: ${target_x},${target_y}, size: ${width}x${height}"
     
     # Get window count before spawning
-    windows_before=$(hyprctl clients -j)
-    count_before=$(echo "$windows_before" | jq 'length')
+    local windows_before=$(hyprctl clients -j)
+    local count_before=$(echo "$windows_before" | jq 'length')
     
     # Launch terminal directly in special workspace to avoid visible spawn
     hyprctl dispatch exec "[float; size $width $height; workspace special:scratchpad silent] $TERMINAL_CMD"
@@ -193,10 +253,10 @@ spawn_terminal() {
     sleep 0.1
     
     # Get windows after spawning
-    windows_after=$(hyprctl clients -j)
-    count_after=$(echo "$windows_after" | jq 'length')
+    local windows_after=$(hyprctl clients -j)
+    local count_after=$(echo "$windows_after" | jq 'length')
     
-    new_addr=""
+    local new_addr=""
     
     if [ "$count_after" -gt "$count_before" ]; then
         # Find the new window by comparing before/after lists


### PR DESCRIPTION
# Pull Request

## Description
Fixed dropdown terminal positioning issues on monitors with non-1.0 scaling factors (e.g., 1.25x, 1.5x, 0.75x). The script now correctly calculates logical coordinate space by dividing physical monitor dimensions by the scale factor, ensuring proper centering and positioning regardless of monitor scaling.

**Changes made:**
- Updated `calculate_dropdown_position()` to compute logical dimensions from physical resolution ÷ scale
- Added proper scaling support with both `bc` (preferred) and integer math fallbacks
- Improved centering logic to work with scaled coordinate space
- Enhanced debug output to show both physical and logical resolutions
- Removed dependency on `X_PERCENT` configuration (auto-centers based on width)

Fixes #782

## Type of change
Please put an `x` in the boxes that apply:
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist
Please put an `x` in the boxes that apply:
- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Additional context
The issue occurred because Hyprland reports physical monitor resolution (e.g., 3440x1440) along with a scale factor (e.g., 1.25), but window positioning uses logical coordinates. Previously, the script used physical dimensions directly, causing incorrect positioning on scaled monitors.

**Technical details:**
- Scale 1.0: Physical 3440x1440 = Logical 3440x1440 ✓
- Scale 1.25: Physical 3440x1440 = Logical 2752x1152 (3440÷1.25)
- Scale 0.75: Physical 3440x1440 = Logical 4587x1920 (3440÷0.75)

The fix ensures calculations use the correct logical coordinate space for any scaling factor.