### PR TITLE
 UserSettings.conf  increase ANR Threshold

### DIFF
--- a/config/hypr/UserConfigs/UserSettings.conf
+++ b/config/hypr/UserConfigs/UserSettings.conf
@@ -86,6 +86,8 @@ misc {
   focus_on_activate = false
   initial_workspace_tracking = 0
   middle_click_paste = false
+  enable_anr_dialog = true    # Application not Responding (ANR)
+  anr_missed_pings = 15       # ANR Threshold default 1 is too low
 }
 
 #opengl {


### PR DESCRIPTION
  enable_anr_dialog = true    # Application not Responding (ANR)
  anr_missed_pings = 15       # ANR Threshold default 1 is too low

# Pull Request

## Description

 New Hyprland feature,  Application Not Responding watchdog. 
 Default threshold of one (1)  missed ping is too low.  Python apps like WayPaper will trigger it 
 Changing default to 15  

## Type of change
 
- [x] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
  [X] I have tested my code locally and it works as expected.
- [X] All new and existing tests passed.
