### PR TITLE
WindowRules.conf xwayland no blur

### DIFF
--- a/config/hypr/UserConfigs/WindowRules.conf
+++ b/config/hypr/UserConfigs/WindowRules.conf
@@ -21,11 +21,11 @@ windowrule = tag +browser, class:^(zen-alpha|zen)$
 # when moving objects in resolve a large border is produced 
 # This rule prevents that and serves as a template for any problematic xwayland apps
 
-windowrulev = noblur, class:^(\bresolve\b)$, xwayland:1
+windowrule = noblur, class:^(\bresolve\b)$, xwayland:1
 # This is a general rule for xwayland apps but can have other consequences 
 # for one user it impacted EMACs so it's disabled by default 
 # It's here as a reference or for quick triage
-#windowrulev2 = noblur, xwayland:1
+#windowrule = noblur, xwayland:1
 
 # notif tags
 windowrule = tag +notif, class:^(swaync-control-center|swaync-notification-window|swaync-client|class)$

--- a/config/hypr/UserConfigs/WindowRules.conf
+++ b/config/hypr/UserConfigs/WindowRules.conf
@@ -17,16 +17,6 @@ windowrule = tag +browser, class:^(Brave-browser(-beta|-dev|-unstable)?)$
 windowrule = tag +browser, class:^([Tt]horium-browser|[Cc]achy-browser)$
 windowrule = tag +browser, class:^(zen-alpha|zen)$
 
-#xwayland related rules
-# when moving objects in resolve a large border is produced 
-# This rule prevents that and serves as a template for any problematic xwayland apps
-
-windowrule = noblur, class:^(\bresolve\b)$, xwayland:1
-# This is a general rule for xwayland apps but can have other consequences 
-# for one user it impacted EMACs so it's disabled by default 
-# It's here as a reference or for quick triage
-#windowrule = noblur, xwayland:1
-
 # notif tags
 windowrule = tag +notif, class:^(swaync-control-center|swaync-notification-window|swaync-client|class)$
 
@@ -234,3 +224,13 @@ layerrule = ignorealpha 0.5, quickshell:overview
 
 #layerrule = ignorezero, overview
 #layerrule = blur, overview
+
+#xwayland related rules
+# when moving objects in resolve a large border is produced 
+# This rule prevents that and serves as a template for any problematic xwayland apps
+windowrule = noblur, class:^(\bresolve\b)$, xwayland:1
+
+# This is a general rule for xwayland apps but can have other consequences 
+# for one user it impacted EMACs so it's disabled by default 
+# It's here as a reference or for quick triage
+#windowrule = noblur, xwayland:1

--- a/config/hypr/UserConfigs/WindowRules.conf
+++ b/config/hypr/UserConfigs/WindowRules.conf
@@ -17,6 +17,16 @@ windowrule = tag +browser, class:^(Brave-browser(-beta|-dev|-unstable)?)$
 windowrule = tag +browser, class:^([Tt]horium-browser|[Cc]achy-browser)$
 windowrule = tag +browser, class:^(zen-alpha|zen)$
 
+#xwayland related rules
+# when moving objects in resolve a large border is produced 
+# This rule prevents that and serves as a template for any problematic xwayland apps
+
+windowrulev = noblur, class:^(\bresolve\b)$, xwayland:1
+# This is a general rule for xwayland apps but can have other consequences 
+# for one user it impacted EMACs so it's disabled by default 
+# It's here as a reference or for quick triage
+#windowrulev2 = noblur, xwayland:1
+
 # notif tags
 windowrule = tag +notif, class:^(swaync-control-center|swaync-notification-window|swaync-client|class)$
 


### PR DESCRIPTION

# Pull Request

## Description
 Adding default rule for Davinci Resolve to resolve huge border issue when moving assets.  Also a disabled noblur rule for xwayland if needed. especially for testing is that's their issue with an xwayland app.   This also serves as an easy template to add more xwaylands apps causing issue 


## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x ] **New feature** (non-breaking change which adds functionality)
- [x] **Documentation update** (non-breaking change; modified files are limited to the documentations)
 
## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] My change requires a change to the documentation.
- [x] I have tested my code locally and it works as expected.

Tested with Davinci-Resolve   