### PR TITLE
change the "when available" to "when-available"

### DIFF
--- a/config/swaync/config.json
+++ b/config/swaync/config.json
@@ -23,7 +23,7 @@
   "control-center-width": 450,
   "control-center-height": 720,
   "keyboard-shortcuts": true,
-  "image-visibility": "when available",
+  "image-visibility": "when-available",
   "transition-time": 200,
   "hide-on-clear": false,
   "hide-on-action": true,


### PR DESCRIPTION
# Pull Request

## Description

In your swaync config.json, the image-visibility value is set to "when available", but according to the official documentation, it should be "when-available" (with a dash).

I have attached screenshots from the official docs for reference:
Link : https://man.archlinux.org/man/swaync.5.en

I have updated the config to use the correct value.

## Screenshots
<img width="805" height="135" alt="image" src="https://github.com/user-attachments/assets/d6164f15-e49d-4af3-9549-e0292271bc82" />

<img width="1448" height="46" alt="image" src="https://github.com/user-attachments/assets/c175d3e4-2bc1-4b57-b5bb-4e2b8039bdca" />

