### PR TITLE
Fix HiDPI scaling for Asahi Linux (Apple Silicon Macs)

### DIFF
--- a/config/hypr/UserConfigs/ENVariables.conf
+++ b/config/hypr/UserConfigs/ENVariables.conf
@@ -31,14 +31,14 @@ env = QT_QUICK_CONTROLS_STYLE,org.hyprland.style
 # Set same value if you use scaling in Monitors.conf
 # 1 is 100% 1.5 is 150%
 # see https://wiki.hyprland.org/Configuring/XWayland/
-env = GDK_SCALE,1
-env = QT_SCALE_FACTOR,1
+env = GDK_SCALE,2
+env = QT_SCALE_FACTOR,2
 
 # Bibata-Modern-Ice-Cursor
 # NOTE! You must have the hyprcursor version to activate this.
 # https://wiki.hyprland.org/Hypr-Ecosystem/hyprcursor/
-#env = HYPRCURSOR_THEME,Bibata-Modern-Ice
-#env = HYPRCURSOR_SIZE,24
+env = HYPRCURSOR_THEME,Bibata-Modern-Ice
+env = HYPRCURSOR_SIZE,24
 
 # firefox
 env = MOZ_ENABLE_WAYLAND,1


### PR DESCRIPTION
## Description
This PR fixes application scaling issues on Apple Silicon Macs running Asahi Linux with Hyprland.

## Problem
Browsers and GTK/Qt applications render at half size on MacBook Retina displays (2560x1600), making text unreadable despite Hyprland having correct 2x monitor scaling.

## Solution
Updated environment variables to match monitor scaling:
- Set `GDK_SCALE=2` for GTK applications
- Set `QT_SCALE_FACTOR=2` for Qt applications
- Enabled Bibata cursor theme with appropriate size (24)

## Testing
Tested on MacBook Pro M2 13" running Asahi Fedora with 2560x1600 display.

## Impact
This fix will help all Asahi Linux users (and other HiDPI display users) who install these dotfiles, as Retina displays are standard on all Apple Silicon Macs.

Before: Browser text was tiny and unreadable
After: Proper 2x scaling matches the system scale

Fixes tiny application rendering on HiDPI displays.