### PR TITLE
fix: Update WallustSwww.sh to support binary swww cache (v0.11+)

### DIFF
--- a/config/hypr/scripts/WallustSwww.sh
+++ b/config/hypr/scripts/WallustSwww.sh
@@ -19,21 +19,28 @@ cache_file="$cache_dir$current_monitor"
 echo $cache_file
 # Check if the cache file exists for the current monitor output
 if [ -f "$cache_file" ]; then
-    # Get the wallpaper path from the cache file
-    wallpaper_path=$(grep -v 'Lanczos3' "$cache_file" | head -n 1)
-    echo $wallpaper_path
-    # symlink the wallpaper to the location Rofi can access
-    if ln -sf "$wallpaper_path" "$HOME/.config/rofi/.current_wallpaper"; then
-        ln_success=true  # Set the flag to true upon successful execution
-    fi
-    # copy the wallpaper for wallpaper effects
-	cp -r "$wallpaper_path" "$HOME/.config/hypr/wallpaper_effects/.wallpaper_current"
+  # Get the wallpaper path from the cache file
+  wallpaper_path=$(grep -v 'Lanczos3' "$cache_file" | head -n 1)
+  # Fallback: If the specified wallpaper path doesn't point to a valid file,
+  # it likely means the cache file is in a binary format. As a workaround,
+  # try extracting readable strings from the cache and use the first relevant line as the wallpaper path.
+  if [[ ! -f "$wallpaper_path" ]]; then
+    echo "[WARN] Binary file format detected, attempting to parse strings..."
+    wallpaper_path=$(strings "$cache_file" | grep -v 'Lanczos3' | head -n 1)
+  fi
+  echo $wallpaper_path
+  # symlink the wallpaper to the location Rofi can access
+  if ln -sf "$wallpaper_path" "$HOME/.config/rofi/.current_wallpaper"; then
+    ln_success=true # Set the flag to true upon successful execution
+  fi
+  # copy the wallpaper for wallpaper effects
+  cp -r "$wallpaper_path" "$HOME/.config/hypr/wallpaper_effects/.wallpaper_current"
 fi
 
 # Check the flag before executing further commands
 if [ "$ln_success" = true ]; then
-    # execute wallust
-	echo 'about to execute wallust'
-    # execute wallust skipping tty and terminal changes
-    wallust run "$wallpaper_path" -s &
+  # execute wallust
+  echo 'about to execute wallust'
+  # execute wallust skipping tty and terminal changes
+  wallust run "$wallpaper_path" -s &
 fi


### PR DESCRIPTION
# Pull Request

## Description

Starting with `swww` version 0.11.0, the cache file stored in `~/.cache/swww/<monitor>` is now in binary format.
The original script used `grep` directly on the file, which fails or returns incorrect output with the new binary format.
This PR updates the parsing logic to use `strings` to safely extract the wallpaper path from the binary data.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] My change requires a change to the documentation.
- [ ]I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.


Tested on Fedora 42 + swww 0.11.0