### PR TITLE
Fix/wallust refresh race

### DIFF
--- a/config/hypr/UserConfigs/UserKeybinds.conf
+++ b/config/hypr/UserConfigs/UserKeybinds.conf
@@ -68,6 +68,11 @@ bindln = ALT_L, SHIFT_L, exec, $scriptsDir/SwitchKeyboardLayout.sh # Change keyb
 bindln = SHIFT_L, ALT_L, exec, $scriptsDir/Tak0-Per-Window-Switch.sh # Change keyboard layout locally for each window
 bind = $mainMod ALT, C, exec, $UserScripts/RofiCalc.sh # calculator (qalculate)
 
+# Move current workspaces to monitors (left right up or down)
+bind = $mainMod CTRL, F9, movecurrentworkspacetomonitor, l #move current workspace to LEFT monitor
+bind = $mainMod CTRL, F10, movecurrentworkspacetomonitor, r #move current workspace to RIGHT monitor
+bind = $mainMod CTRL, F11, movecurrentworkspacetomonitor, u #move current workspace to UP monitor
+bind = $mainMod CTRL, F12, movecurrentworkspacetomonitor, d #move current workspace to DOWN monitor
 
 # For passthrough keyboard into a VM
 # bind = $mainMod ALT, P, submap, passthru

--- a/config/hypr/UserScripts/WallpaperAutoChange.sh
+++ b/config/hypr/UserScripts/WallpaperAutoChange.sh
@@ -31,7 +31,10 @@ while true; do
 		done \
 		| sort -n | cut -d':' -f2- \
 		| while read -r img; do
-			swww img -o $focused_monitor "$img" 
+			swww img -o $focused_monitor "$img"
+			# Regenerate colors from the exact image path to avoid cache races
+			$HOME/.config/hypr/scripts/WallustSwww.sh "$img"
+			# Refresh UI components that depend on wallust output
 			$wallust_refresh
 			sleep $INTERVAL
 			

--- a/config/hypr/UserScripts/WallpaperSelect.sh
+++ b/config/hypr/UserScripts/WallpaperSelect.sh
@@ -168,8 +168,8 @@ apply_image_wallpaper() {
 
   swww img -o "$focused_monitor" "$image_path" $SWWW_PARAMS
 
-  # Run additional scripts
-  "$SCRIPTSDIR/WallustSwww.sh"
+  # Run additional scripts (pass the image path to avoid cache race conditions)
+  "$SCRIPTSDIR/WallustSwww.sh" "$image_path"
   sleep 2
   "$SCRIPTSDIR/Refresh.sh"
   sleep 1

--- a/config/hypr/initial-boot.sh
+++ b/config/hypr/initial-boot.sh
@@ -10,7 +10,7 @@
 # Variables
 scriptsDir=$HOME/.config/hypr/scripts
 wallpaper=$HOME/.config/hypr/wallpaper_effects/.wallpaper_current
-waybar_style="$HOME/.config/waybar/style/[Extra] Modern-Combined - Transparent.css"
+waybar_style="$HOME/.config/waybar/style/[Extra] Neon Circuit.css"
 kvantum_theme="catppuccin-mocha-blue"
 color_scheme="prefer-dark"
 gtk_theme="Flat-Remix-GTK-Blue-Dark"

--- a/config/hypr/scripts/RefreshNoWaybar.sh
+++ b/config/hypr/scripts/RefreshNoWaybar.sh
@@ -31,8 +31,9 @@ done
 # quit quickshell & relaunch quickshell
 #pkill qs && qs &
 
-# Wallust refresh
-${SCRIPTSDIR}/WallustSwww.sh &
+# Wallust refresh (synchronous to ensure colors are ready)
+${SCRIPTSDIR}/WallustSwww.sh
+sleep 0.2
 
 # reload swaync
 swaync-client --reload-config

--- a/config/hypr/v2.3.17
+++ b/config/hypr/v2.3.17
@@ -1,0 +1,5 @@
+### https://github.com/JaKooLit ###
+## https://github.com/JaKooLit/Hyprland-Dots
+## This is to have a reference of which version would be
+
+## note that this will always be higher than the released versions

--- a/copy.sh
+++ b/copy.sh
@@ -3,7 +3,7 @@
 
 clear
 wallpaper=$HOME/.config/hypr/wallpaper_effects/.wallpaper_current
-waybar_style="$HOME/.config/waybar/style/[Extra] Modern-Combined - Transparent.css"
+waybar_style="$HOME/.config/waybar/style/[Extra] Neon Circuit.css"
 waybar_config="$HOME/.config/waybar/configs/[TOP] Default"
 waybar_config_laptop="$HOME/.config/waybar/configs/[TOP] Default Laptop" 
 


### PR DESCRIPTION
# Pull Request

## Description
This PR fixes nondeterministic theme updates when changing wallpapers by removing the race against swww’s cache and ensuring wallust always receives the correct image path and completes before UI reloads.

Changes
•  WallustSwww.sh: accept explicit image path; if not provided, retry reading from ~/.cache/swww/<monitor> briefly; always run wallust run -s when a valid path is found; update links and current wallpaper path reliably
•  WallpaperSelect.sh: pass the selected image path directly to WallustSwww.sh after swww img
•  RefreshNoWaybar.sh: call WallustSwww.sh synchronously (no background) and wait briefly before reloading swaync so colors are ready
•  WallpaperAutoChange.sh: for each rotated image, call WallustSwww.sh with the image path before running the (no-waybar) refresh

Why
•  Previously, WallustSwww.sh depended on swww cache timing; immediately after swww img, the cache file may not exist yet or contain the expected content. That led to no wallust regeneration and stale colors.
•  Passing the image path removes the dependency on cache timing and ensures colors regenerate for waybar, rofi, kitty, and hypr immediately.

Test plan
•  Manual selection (SUPER+W):
•  Observe updates to:
◦  ~/.config/waybar/wallust/colors-waybar.css
◦  ~/.config/rofi/wallust/colors-rofi.rasi
◦  ~/.config/kitty/kitty-themes/01-Wallust.conf
◦  ~/.config/hypr/wallust/wallust-hyprland.conf
•  Waybar reloads and border colors reflect the new palette
•  Auto-rotate (WallpaperAutoChange.sh):
•  Colors update on each rotation without manual wallust or refresh

Acknowledgements
•  Tested-by: ddubs & KalebNH 

## Type of change

- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [X] I have added tests to cover my changes.
- [X] I have tested my code locally and it works as expected.
- [X] All new and existing tests passed.

