### PR TITLE
Fix/wallust refresh race

### DIFF
--- a/config/hypr/UserScripts/WallpaperAutoChange.sh
+++ b/config/hypr/UserScripts/WallpaperAutoChange.sh
@@ -31,7 +31,10 @@ while true; do
 		done \
 		| sort -n | cut -d':' -f2- \
 		| while read -r img; do
-			swww img -o $focused_monitor "$img" 
+			swww img -o $focused_monitor "$img"
+			# Regenerate colors from the exact image path to avoid cache races
+			$HOME/.config/hypr/scripts/WallustSwww.sh "$img"
+			# Refresh UI components that depend on wallust output
 			$wallust_refresh
 			sleep $INTERVAL
 			

--- a/config/hypr/UserScripts/WallpaperSelect.sh
+++ b/config/hypr/UserScripts/WallpaperSelect.sh
@@ -168,8 +168,8 @@ apply_image_wallpaper() {
 
   swww img -o "$focused_monitor" "$image_path" $SWWW_PARAMS
 
-  # Run additional scripts
-  "$SCRIPTSDIR/WallustSwww.sh"
+  # Run additional scripts (pass the image path to avoid cache race conditions)
+  "$SCRIPTSDIR/WallustSwww.sh" "$image_path"
   sleep 2
   "$SCRIPTSDIR/Refresh.sh"
   sleep 1

--- a/config/hypr/scripts/RefreshNoWaybar.sh
+++ b/config/hypr/scripts/RefreshNoWaybar.sh
@@ -31,8 +31,9 @@ done
 # quit quickshell & relaunch quickshell
 #pkill qs && qs &
 
-# Wallust refresh
-${SCRIPTSDIR}/WallustSwww.sh &
+# Wallust refresh (synchronous to ensure colors are ready)
+${SCRIPTSDIR}/WallustSwww.sh
+sleep 0.2
 
 # reload swaync
 swaync-client --reload-config

--- a/config/swaync/config.json
+++ b/config/swaync/config.json
@@ -23,7 +23,7 @@
   "control-center-width": 450,
   "control-center-height": 720,
   "keyboard-shortcuts": true,
-  "image-visibility": "when available",
+  "image-visibility": "when-available",
   "transition-time": 200,
   "hide-on-clear": false,
   "hide-on-action": true,


### PR DESCRIPTION
# Pull Request

## Description
This PR fixes nondeterministic theme updates when changing wallpapers by removing the race against swww’s cache and ensuring wallust always receives the correct image path and completes before UI reloads.

Changes
• WallustSwww.sh: accept explicit image path; if not provided, retry reading from ~/.cache/swww/ briefly; always run wallust run -s when a valid path is found; update links and current wallpaper path reliably
• WallpaperSelect.sh: pass the selected image path directly to WallustSwww.sh after swww img
• RefreshNoWaybar.sh: call WallustSwww.sh synchronously (no background) and wait briefly before reloading swaync so colors are ready
• WallpaperAutoChange.sh: for each rotated image, call WallustSwww.sh with the image path before running the (no-waybar) refresh

Why
• Previously, WallustSwww.sh depended on swww cache timing; immediately after swww img, the cache file may not exist yet or contain the expected content. That led to no wallust regeneration and stale colors.
• Passing the image path removes the dependency on cache timing and ensures colors regenerate for waybar, rofi, kitty, and hypr immediately.

Test plan
• Manual selection (SUPER+W):
• Observe updates to:
◦ ~/.config/waybar/wallust/colors-waybar.css
◦ ~/.config/rofi/wallust/colors-rofi.rasi
◦ ~/.config/kitty/kitty-themes/01-Wallust.conf
◦ ~/.config/hypr/wallust/wallust-hyprland.conf
• Waybar reloads and border colors reflect the new palette
• Auto-rotate (WallpaperAutoChange.sh):
• Colors update on each rotation without manual wallust or refresh

Acknowledgements
• Tested-by: ddubs & KalebNH

## Type of change

Please put an `x` in the boxes that apply:

- [X] **Bug fix** (non-breaking change which fixes an issue)

-## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [X] My change requires a change to the documentation.
- [X] I want to add something in Hyprland-Dots wiki.
- [X] I have added tests to cover my changes.
- [X] I have tested my code locally and it works as expected.
- [ ] All new tests passed.
