### PR TITLE
fix(sddm): set Backgrounds/default as primary and update fallbacks;

### DIFF
--- a/config/hypr/UserScripts/WallpaperEffects.sh
+++ b/config/hypr/UserScripts/WallpaperEffects.sh
@@ -108,31 +108,41 @@ main
 sleep 1
 
 if [[ -n "$choice" ]]; then
-  sddm_simple="/usr/share/sddm/themes/simple_sddm_2"
-  if [ -d "$sddm_simple" ]; then
-  
-	# Check if yad is running to avoid multiple yad notification
-	if pidof yad > /dev/null; then
-	  killall yad
-	fi
-	
-	if yad --info --text="Set current wallpaper as SDDM background?\n\nNOTE: This only applies to SIMPLE SDDM v2 Theme" \
-    --text-align=left \
-    --title="SDDM Background" \
-    --timeout=5 \
-    --timeout-indicator=right \
-    --button="yad-yes:0" \
-    --button="yad-no:1" \
-    ; then
+  # Resolve SDDM themes directory (standard and NixOS path)
+  sddm_themes_dir=""
+  if [ -d "/usr/share/sddm/themes" ]; then
+    sddm_themes_dir="/usr/share/sddm/themes"
+  elif [ -d "/run/current-system/sw/share/sddm/themes" ]; then
+    sddm_themes_dir="/run/current-system/sw/share/sddm/themes"
+  fi
 
-    # Check if terminal exists
-    if ! command -v "$terminal" &>/dev/null; then
-    notify-send -i "$iDIR/ja.png" "Missing $terminal" "Install $terminal to enable setting of wallpaper background"
-    exit 1
-    fi
+  if [ -n "$sddm_themes_dir" ]; then
+    sddm_simple="$sddm_themes_dir/simple_sddm_2"
 
-	exec $SCRIPTSDIR/sddm_wallpaper.sh --effects
-    
+    # Only prompt if theme exists and its Backgrounds directory is writable
+    if [ -d "$sddm_simple" ] && [ -w "$sddm_simple/Backgrounds" ]; then
+      # Check if yad is running to avoid multiple yad notification
+      if pidof yad > /dev/null; then
+        killall yad
+      fi
+
+      if yad --info --text="Set current wallpaper as SDDM background?\n\nNOTE: This only applies to SIMPLE SDDM v2 Theme" \
+        --text-align=left \
+        --title="SDDM Background" \
+        --timeout=5 \
+        --timeout-indicator=right \
+        --button="yad-yes:0" \
+        --button="yad-no:1" \
+        ; then
+
+        # Check if terminal exists
+        if ! command -v "$terminal" &>/dev/null; then
+          notify-send -i "$iDIR/ja.png" "Missing $terminal" "Install $terminal to enable setting of wallpaper background"
+          exit 1
+        fi
+
+        exec "$SCRIPTSDIR/sddm_wallpaper.sh" --effects
+      fi
     fi
   fi
 fi

--- a/config/hypr/UserScripts/WallpaperSelect.sh
+++ b/config/hypr/UserScripts/WallpaperSelect.sh
@@ -101,9 +101,21 @@ menu() {
 # Offer SDDM Simple Wallpaper Option (only for non-video wallpapers)
 set_sddm_wallpaper() {
   sleep 1
-  sddm_simple="/usr/share/sddm/themes/simple_sddm_2"
 
-  if [ -d "$sddm_simple" ]; then
+  # Resolve SDDM themes directory (standard and NixOS path)
+  local sddm_themes_dir=""
+  if [ -d "/usr/share/sddm/themes" ]; then
+    sddm_themes_dir="/usr/share/sddm/themes"
+  elif [ -d "/run/current-system/sw/share/sddm/themes" ]; then
+    sddm_themes_dir="/run/current-system/sw/share/sddm/themes"
+  fi
+
+  [ -z "$sddm_themes_dir" ] && return 0
+
+  local sddm_simple="$sddm_themes_dir/simple_sddm_2"
+
+  # Only prompt if theme exists and its Backgrounds directory is writable
+  if [ -d "$sddm_simple" ] && [ -w "$sddm_simple/Backgrounds" ]; then
 
     # Check if yad is running to avoid multiple notifications
     if pidof yad >/dev/null; then
@@ -123,9 +135,9 @@ set_sddm_wallpaper() {
         notify-send -i "$iDIR/error.png" "Missing $terminal" "Install $terminal to enable setting of wallpaper background"
         exit 1
       fi
-	  
-	  exec $SCRIPTSDIR/sddm_wallpaper.sh --normal
-    
+
+      exec "$SCRIPTSDIR/sddm_wallpaper.sh" --normal
+
     fi
   fi
 }


### PR DESCRIPTION

# Pull Request

## Description

This PR fixes the “Set as SDDM background” flow for the simple_sddm_2 theme.

What changed
•  Prefer copying to Backgrounds/default (no extension) for simple_sddm_2.   (Current method) 
•  Update Backgrounds/default.jpg and default.png as fallbacks when they exist.  (Future proofing) 
•  Detect SDDM themes dir at /usr/share/sddm/themes and /run/current-system/sw/share/sddm/themes (NixOS).
•  Only show the SDDM prompt when the theme exists and Backgrounds is writable (avoids misleading prompts on read-only paths).
•  Skip runtime updates on NixOS since this repo’s NixOS config does not use SDDM.

Files touched
•  config/hypr/scripts/sddm_wallpaper.sh
•  config/hypr/UserScripts/WallpaperSelect.sh
•  config/hypr/UserScripts/WallpaperEffects.sh

Testing
•  Verified the prompt appears only when simple_sddm_2 is installed and writable.
•  Confirmed Backgrounds/default is updated; default.jpg/png updated when present.

Impact
•  No behavior change for Arch/Debian/Fedora/openSUSE users with simple_sddm_2 installed, except more reliable updates.
•  NixOS users won’t be prompted or will be safely skipped when themes are read-only.

This is just some cleanup after working on the wallpaper theme issue.  

It also helps lay ground work for adding SDDM to NixOS in the future. 

## Type of change

Please put an `x` in the boxes that apply:

- [X] **Bug fix** (non-breaking change which fixes an issue)
 

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [X] I have tested my code locally and it works as expected.
- [X] All new and existing tests passed.
