### PR TITLE
Add gestures option for Hyprland 0.51+

### DIFF
--- a/config/hypr/UserConfigs/UserSettings.conf
+++ b/config/hypr/UserConfigs/UserSettings.conf
@@ -73,6 +73,13 @@ gestures {
   workspace_swipe_create_new = true 
   workspace_swipe_forever = true
   #workspace_swipe_use_r = true #uncomment if wanted a forever create a new workspace with swipe right
+  
+  # For Hyprland 0.51+ only! Uncomment the code below and comment out the above all 'workspace_swipe' line
+  # gesture = 3, horizontal, workspace  
+  # gesture = 3, down, mod: SUPER, close 
+  # gesture = 4, horizontal, resize 
+  # gesture = 4, vertical, resize  
+
 }
 
 misc {


### PR DESCRIPTION
# Pull Request

## Description
Changes:
- Added commented gesture block for Hyprland 0.51+ with  3-finger swipes (workspace), and 4-finger swipes (resize).
- Kept legacy gestures block for compatibility with older Hyprland versions.
- Added clear warning comment to guide users on switching to new gestures code
Motivation: Prevent errors on non-Arch distros (e.g., Ubuntu/Debian) with older Hyprland versions while introducing modern gestures for 0.51+ users
Fixes: Addresses potential compatibility issues with Hyprland 0.51 gesture deprecation.

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ x ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [ x ] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [ x ] My code follows the code style of this project.
- [ x ] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ x ] I have added tests to cover my changes.
- [ x ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

