### PR TITLE
Update Startup_Apps.conf improve dropdown

### DIFF
--- a/config/hypr/UserConfigs/Startup_Apps.conf
+++ b/config/hypr/UserConfigs/Startup_Apps.conf
@@ -20,6 +20,10 @@ exec-once = swww-daemon --format xrgb
 exec-once = dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP
 exec-once = systemctl --user import-environment WAYLAND_DISPLAY XDG_CURRENT_DESKTOP
 
+# Initialize Drop Down terminal - See Bug#810 https://github.com/JaKooLit/Hyprland-Dots/issues/810#issuecomment-3351947644
+exec-once = $HOME/.config/hypr/scripts/Dropterminal.sh kitty &
+
+
 # Polkit (Polkit Gnome / KDE)
 exec-once = $scriptsDir/Polkit.sh
 


### PR DESCRIPTION
See bug 810 
https://github.com/JaKooLit/Hyprland-Dots/issues/810#issuecomment-3351947644

I tested this and it  works well for me  Two other users report it worked for them also. 

Solution provided by `[0youcef]`   `(https://github.com/0youcef)`

# Pull Request

## Description
85% of the time when trying to use the keybindings for the drop down terminal, including custom keybindings, it hides the application in the background, or brings an app in a different workspace into the current one, instead of the terminal popping up.


## Type of change

Please put an `x` in the boxes that apply:

- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [X] I have tested my code locally and it works as expected.
