### PR TITLE
Update Dropterminal.sh to work on vertical monitors

### DIFF
--- a/config/hypr/scripts/Dropterminal.sh
+++ b/config/hypr/scripts/Dropterminal.sh
@@ -206,7 +206,7 @@ calculate_dropdown_position() {
     debug_echo "Window size: ${width}x${height} (logical pixels)"
     debug_echo "Final position: x=$final_x, y=$final_y (logical coordinates)"
     debug_echo "Hyprland will scale these to physical coordinates automatically"
-
+    
     echo "$final_x $final_y $width $height $mon_name"
 }
 


### PR DESCRIPTION
# Pull Request

## Description

Since "hyprctl monitors" doesn't modify height and width for vertical monitors, the script was causing the terminal to appear mispositioned. A monitor's vertical orientation is indicated by the "transform" variable. 
I've added a new variable and some logic to account for this.

Added the changes discussed in  #849 

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [x] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.