### PR TITLE
hotfix: remove hypersunset from status group

### DIFF
--- a/config/waybar/ModulesGroups
+++ b/config/waybar/ModulesGroups
@@ -89,7 +89,6 @@
         },
 	"modules": [
 		"custom/power",
-		"custom/nightlight",
 		"custom/lock",
 		"keyboard-state",
 		"custom/keyboard",
@@ -132,7 +131,6 @@
        },
      "modules": [
         "custom/power",
-        "custom/nightlight",
         "custom/lock",
         "custom/logout",
         "custom/reboot"


### PR DESCRIPTION
# Pull Request

## Description

The hypersunset icon is also showing in status group, duplicating it when hovering on power icon.

This PR removes the nightlight from "status" and "power#vert" groups.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

**Before**
<img width="228" height="100" alt="Screenshot_02-nov_20-55-09_30974" src="https://github.com/user-attachments/assets/892f1dc2-a42d-4c46-9611-c2f634a0260f" />

**after**
<img width="219" height="101" alt="Screenshot_02-nov_21-34-32_17108" src="https://github.com/user-attachments/assets/e5a0045d-4b3d-4bb0-8c97-123568827ad8" />
