### PR TITLE
fix(rofi): update RofiBeats shebang to /bin/bash

### DIFF
--- a/config/hypr/UserScripts/RofiBeats.sh
+++ b/config/hypr/UserScripts/RofiBeats.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # /* ---- 💫 https://github.com/JaKooLit 💫 ---- */  ##
 # RofiBeats - unified, dynamic UI (add, remove, manage, play)
 


### PR DESCRIPTION
This patch updates the shebang in RofiBeats.sh from /bin/bash to /usr/bin/env bash