### PR TITLE
feat: improved keybindings $mainMod left-right to work within groups

### DIFF
--- a/config/hypr/configs/Keybinds.conf
+++ b/config/hypr/configs/Keybinds.conf
@@ -151,10 +151,10 @@ bindd = $mainMod ALT, up, swap window up, swapwindow, u
 bindd = $mainMod ALT, down, swap window down, swapwindow, d
 
 # Move focus with mainMod + arrow keys
-bindd = $mainMod, left, focus left, movefocus, l
-bindd = $mainMod, right, focus right, movefocus, r
-bindd = $mainMod, up, focus up, movefocus, u
-bindd = $mainMod, down, focus down, movefocus, d
+bindd = $mainMod, right, focus right,  execr   , bash -c 'if [ $(hyprctl activewindow -j | jq "(.grouped|length==0) or (.address==.grouped[-1])") = "true" ]; then hyprctl dispatch movefocus r; else hyprctl dispatch changegroupactive f; fi'
+bindd = $mainMod, left , focus left , execr    , bash -c 'if [ $(hyprctl activewindow -j | jq "(.grouped|length==0) or (.address==.grouped[0])") = "true" ]; then hyprctl dispatch movefocus l; else hyprctl dispatch changegroupactive b; fi'
+bindd = $mainMod, up   , focus up   , movefocus, u
+bindd = $mainMod, down , focus down , movefocus, d
 
 # Workspaces related
 bindd = $mainMod, tab, next workspace, workspace, m+1


### PR DESCRIPTION
# Pull Request

## Description

Please read these instructions and remove unnecessary text.

The keybindings $mainMod left,right are changed so that they are workd within groups.

I was used to this feature before using hyprland in i3 and tryied to include it in hyprland. As I switched to this Dotfiles I would appriciate when they are added to the repo.

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [xI have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

## Additional context
