### PR TITLE
fix: Fix wallpaper selector showing wrong wallpaper when filename contains dots

### DIFF
--- a/config/hypr/UserScripts/WallpaperSelect.sh
+++ b/config/hypr/UserScripts/WallpaperSelect.sh
@@ -93,7 +93,7 @@ menu() {
       fi
       printf "%s\x00icon\x1f%s\n" "$pic_name" "$cache_preview_image"
     else
-      printf "%s\x00icon\x1f%s\n" "$(echo "$pic_name" | cut -d. -f1)" "$pic_path"
+      printf "%s\x00icon\x1f%s\n" "$pic_name" "$pic_path"
     fi
   done
 }


### PR DESCRIPTION
# Pull Request

## Description

This fixes a bug where wallpapers with dots in their filenames (e.g., `01. Catppuccin Latte.jpg`) were displayed incorrectly in the rofi wallpaper picker, and selecting them applied the wrong wallpaper.

**Root cause:** Line 96 used `cut -d. -f1` which truncates at the *first* dot, so `01. Catppuccin Latte.jpg` became just `01`. Multiple wallpapers with the same number prefix showed identical labels.

**Selection bug:** When user selected `01`, the `find -iname "01.*" -print -quit` on line 225 returned the first alphabetical match, not the intended file.

**Solution:** Display the full filename `$pic_name` (consistent with GIF handling on line 87 and video handling on line 94). The existing sed on line 222 correctly strips only the file extension for the find command.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Additional context

The fix is minimal (1 line change) and makes image handling consistent with existing GIF and video handling in the same function.