### PR TITLE
fix: Check for empty strings in place parts and prevent coordinates from printing when a place is found.

### DIFF
--- a/config/hypr/UserScripts/Weather.py
+++ b/config/hypr/UserScripts/Weather.py
@@ -455,15 +455,15 @@ def fetch_aqi(lat: float, lon: float) -> Optional[Dict[str, Any]]:
 def extract_place_parts_nominatim(data_dict: JSONDict) -> List[str]:
     address = ensure_dict(data_dict.get("address"))
     candidates = [data_dict.get("name"), address.get("city"), address.get("town"), address.get("village"), address.get("hamlet")]
-    name = cast(Optional[str], next((c for c in candidates if c is not None), None))
+    name = cast(Optional[str], next((c for c in candidates if c is not None and c != ""), None))
     admin1 = cast(Optional[str], address.get("state"))
     country = cast(Optional[str], address.get("country"))
     parts: List[str] = []
-    if name is not None:
+    if name is not None and name != "":
         parts.append(name)
-    if admin1 is not None:
+    if admin1 is not None and admin1 != "":
         parts.append(admin1)
-    if country is not None:
+    if country is not None and country != "":
         parts.append(country)
     return parts
 
@@ -691,7 +691,7 @@ def build_aqi_info(aqi: Optional[Dict[str, Any]]) -> str:
 def build_place_str(lat: float, lon: float, place: Optional[str]) -> str:
     effective_place = MANUAL_PLACE or ENV_PLACE or place
     if effective_place:
-        return f"{effective_place} ({lat:.3f}, {lon:.3f})"
+        return effective_place
     return f"{lat:.3f}, {lon:.3f}"
 
 


### PR DESCRIPTION
# Pull Request

## Description

Weather API can return empty strings, which is not covered in the script (only None is currently covered). It results in empty address part (in my case, a blank city name).

Also, when a place is found (`effective_place`) the script returns the address string (city, state, country) plus the coordinates. If a place is not found it returns only the coordinates. In small screens such as laptops, the full address plus coordinates gets too long and intersects the other elements in the lock screen.

This PR adds checks for empty strings and removes coordinates from the address string when a place is found.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.


