### PR TITLE
feat : Add OS age feature in fastfetch pokemon config

### DIFF
--- a/config/fastfetch/config-pokemon.jsonc
+++ b/config/fastfetch/config-pokemon.jsonc
@@ -67,6 +67,12 @@
             "keyColor": "green"
         },
         {
+            "type": "command",
+            "key": "󱦟",
+            "keyColor": "magenta",
+            "text": "birth_install=$(stat -c %W /); current=$(date +%s); time_progression=$((current - birth_install)); days_difference=$((time_progression / 86400)); echo $days_difference days"
+        },
+        {
             "type": "custom",
             "format": " ─────────────────────────── "
         },


### PR DESCRIPTION
# Fastfetch pokemon config OS age feature

## Description

Added new OS age feature, which shows the OS installed age, in pokemon fastfetch config.
## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Arch-Hyprland/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Arch-Hyprland/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Arch-Hyprland wiki.
- [x] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Screenshots
https://ibb.co/YBjFx79m


I hope this helps to improve this beautiful project
