### PR TITLE
fix: waybar clock locale

### DIFF
--- a/config/waybar/Modules
+++ b/config/waybar/Modules
@@ -99,7 +99,7 @@
 	"interval": 1,
     //"format": " {:%I:%M %p}", // AM PM format
     "format": " {:%H:%M:%S}", // 24H
-	"format-alt": " {:%H:%M   %Y, %d %B, %A}",
+	"format-alt": " {:L%H:%M   %Y, %d %B, %A}",
 	"tooltip-format": "<tt><small>{calendar}</small></tt>",
 	"calendar": {
 		"mode": "year",
@@ -127,28 +127,28 @@
 "clock#2": {
     //"format": " {:%I:%M %p}", // AM PM format
     "format": "  {:%H:%M}", // 24H
-    "format-alt": "{:%A  |  %H:%M  |  %e %B}",
+    "format-alt": "{:L%A  |  %H:%M  |  %e %B}",
     "tooltip-format": "<big>{:%Y %B}</big>\n<tt><small>{calendar}</small></tt>"
 },
 
 "clock#3": {
-    //"format": "{:%I:%M %p - %d/%b}", //for AM/PM
-    "format": "{:%H:%M - %d/%b}", // 24H
+    //"format": "{:L%I:%M %p - %d/%b}", //for AM/PM
+    "format": "{:L%H:%M - %d/%b}", // 24H
 	"tooltip": false
 },
 
 "clock#4": {
 	"interval": 60,
-    //"format": "{:%B | %a %d, %Y | %I:%M %p}", // AM PM format
-    "format": "{:%B | %a %d, %Y | %H:%M}", // 24H
-	"format-alt": "{:%a %b %d, %G}",
+    //"format": "{:L%B | %a %d, %Y | %I:%M %p}", // AM PM format
+    "format": "{:L%B | %a %d, %Y | %H:%M}", // 24H
+	"format-alt": "{:L%a %b %d, %G}",
 	"tooltip-format": "<big>{:%B %Y}</big>\n<tt><small>{calendar}</small></tt>",
 },
 
 "clock#5": {
     //"format": "{:%A, %I:%M %P}", // AM PM format
     "format": "{:%a %d | %H:%M}", // 24H
-	"format-alt": "{:%A, %d %B, %Y (%R)}",
+	"format-alt": "{:L%A, %d %B, %Y (%R)}",
 	"tooltip-format": "<big>{:%B %Y}</big>\n<tt><small>{calendar}</small></tt>",
 },
 

--- a/config/waybar/configs/[TOP] Everforest
+++ b/config/waybar/configs/[TOP] Everforest
@@ -55,7 +55,7 @@
       "on-click": "rofi -show drun"
 },
 "clock#forest": {
-      "format": "{:%A %d.%m.%Y - %H:%M}",
+      "format": "{:L%A %d.%m.%Y - %H:%M}",
       "tooltip-format": "<span color='#D3C6AA' size='larger'>{:%Y %B}</span>\n<tt>{calendar}</tt>",
       "calendar-weeks-pos": "right",
       "today-format": "<span color='#E67E80' weight='ultrabold'>{}</span>",


### PR DESCRIPTION
# Pull Request

## Description

Waybar clocks are ignoring locale definitions. Following the [instructions in the official wiki](https://github.com/Alexays/Waybar/wiki/Module:-Clock), this PR appends `L` to all clock formats sensible to locale changes (e.g., that contains month names `%b[B]` or weekdays names `%A`).

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots
<img width="339" height="24" alt="image" src="https://github.com/user-attachments/assets/7c61c852-12f3-4035-b9ae-3ad2847ade53" />
<img width="323" height="26" alt="image1" src="https://github.com/user-attachments/assets/8bb9cd4b-60e7-4a58-bfe3-cfc23eecc018" />

