### PR TITLE
feat: Add precise volume adjustment

### DIFF
--- a/config/hypr/configs/Keybinds.conf
+++ b/config/hypr/configs/Keybinds.conf
@@ -106,6 +106,8 @@ bindd = ALT, tab, bring active to top, bringactivetotop
 # Special Keys / Hot Keys
 bindeld = , xf86audioraisevolume, volume up, exec, $scriptsDir/Volume.sh --inc
 bindeld = , xf86audiolowervolume, volume down, exec, $scriptsDir/Volume.sh --dec
+bindeld = ALT, xf86audioraisevolume, volume up, exec, $scriptsDir/Volume.sh --inc-precise
+bindeld = ALT, xf86audiolowervolume, volume down, exec, $scriptsDir/Volume.sh --dec-precise
 bindld = , xf86AudioMicMute, toggle mic mute, exec, $scriptsDir/Volume.sh --toggle-mic
 bindld = , xf86audiomute, toggle mute, exec, $scriptsDir/Volume.sh --toggle
 bindld = , xf86Sleep, sleep, exec, systemctl suspend

--- a/config/hypr/scripts/Volume.sh
+++ b/config/hypr/scripts/Volume.sh
@@ -44,7 +44,7 @@ inc_volume() {
     if [ "$(pamixer --get-mute)" == "true" ]; then
         toggle_mute
     else
-        pamixer -i 5 --allow-boost --set-limit 150 && notify_user
+        pamixer -i "$1" --allow-boost --set-limit 150 && notify_user
     fi
 }
 
@@ -53,7 +53,7 @@ dec_volume() {
     if [ "$(pamixer --get-mute)" == "true" ]; then
         toggle_mute
     else
-        pamixer -d 5 && notify_user
+        pamixer -d "$1" && notify_user
     fi
 }
 
@@ -120,24 +120,41 @@ dec_mic_volume() {
 }
 
 # Execute accordingly
-if [[ "$1" == "--get" ]]; then
-	get_volume
-elif [[ "$1" == "--inc" ]]; then
-	inc_volume
-elif [[ "$1" == "--dec" ]]; then
-	dec_volume
-elif [[ "$1" == "--toggle" ]]; then
-	toggle_mute
-elif [[ "$1" == "--toggle-mic" ]]; then
-	toggle_mic
-elif [[ "$1" == "--get-icon" ]]; then
-	get_icon
-elif [[ "$1" == "--get-mic-icon" ]]; then
-	get_mic_icon
-elif [[ "$1" == "--mic-inc" ]]; then
-	inc_mic_volume
-elif [[ "$1" == "--mic-dec" ]]; then
-	dec_mic_volume
-else
-	get_volume
-fi
+case $1 in
+"--get")
+  get_volume
+  ;;
+"--inc")
+  inc_volume 5
+  ;;
+"--inc-precise")
+  inc_volume 1
+  ;;
+"--dec")
+  dec_volume 5
+  ;;
+"--dec-precise")
+  dec_volume 1
+  ;;
+"--toggle")
+  toggle_mute
+  ;;
+"--toggle-mic")
+  toggle_mic
+  ;;
+"--get-icon")
+  get_icon
+  ;;
+"--get-mic-icon")
+  get_mic_icon
+  ;;
+"--mic-inc")
+  inc_mic_volume
+  ;;
+"--mic-dec")
+  dec_mic_volume
+  ;;
+*)
+  get_volume
+  ;;
+esac


### PR DESCRIPTION
# Pull Request

## Description
Currently volume adjustment with the keyboard is hard coded to increments and decrements of 5. While this is generally acceptable, I like having the ability to adjust volume in increments and decrements of 1 for some applications. I've added this to `UserKeybinds` in my own setup, but I think this is a feature that should be built-in.

## Type of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.