### PR TITLE
fix: cycleprev and cyclenext window bindings solution 1

### DIFF
--- a/config/hypr/configs/Keybinds.conf
+++ b/config/hypr/configs/Keybinds.conf
@@ -85,10 +85,6 @@ bindd = $mainMod SHIFT, E, Quick settings menu, exec, $scriptsDir/Kool_Quick_Set
 # Master Layout
 bindd = $mainMod CTRL, D, remove master, layoutmsg, removemaster
 bindd = $mainMod, I, add master, layoutmsg, addmaster
-# NOTE: J/K bindings are set dynamically by scripts/KeybindsLayoutInit.sh and scripts/ChangeLayout.sh
-# (we intentionally do not bind them statically here to avoid conflicts across layouts)
-# bindd = $mainMod, J, cycle next, layoutmsg, cyclenext
-# bindd = $mainMod, K, cycle previous, layoutmsg, cycleprev
 bindd = $mainMod CTRL, Return, swap with master, layoutmsg, swapwithmaster
 
 # Dwindle Layout
@@ -97,7 +93,9 @@ bindd = $mainMod, P, toggle pseudo (dwindle), pseudo,
 
 # Works on either layout (Master or Dwindle)
 bindd = $mainMod, M, set split ratio 0.3, exec, hyprctl dispatch splitratio 0.3
-
+# Cycle windows globally: J = next, K = previous
+bindd = $mainMod, J, cycle next window, cyclenext
+bindd = $mainMod, K, cycle prev window, cyclenext,prev
 
 # Cycle windows; if floating bring to top
 bindd = ALT, tab, cycle next window, cyclenext

--- a/config/hypr/configs/Startup_Apps.conf
+++ b/config/hypr/configs/Startup_Apps.conf
@@ -19,7 +19,6 @@ exec-once = swww-daemon --format xrgb
 ### Startup ###
 exec-once = dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP
 exec-once = systemctl --user import-environment WAYLAND_DISPLAY XDG_CURRENT_DESKTOP
-exec-once = $scriptsDir/KeybindsLayoutInit.sh
 
 # Drop Down terminal
 # See Bug#810 https://github.com/JaKooLit/Hyprland-Dots/issues/810#issuecomment-3351947644

--- a/config/hypr/scripts/ChangeLayout.sh
+++ b/config/hypr/scripts/ChangeLayout.sh
@@ -8,17 +8,17 @@ LAYOUT=$(hyprctl -j getoption general:layout | jq '.str' | sed 's/"//g')
 
 case $LAYOUT in
 "master")
-	hyprctl keyword general:layout dwindle
-	# SUPER+J/K are global and managed by KeybindsLayoutInit.sh; only manage SUPER+O here
-	hyprctl keyword bind SUPER,O,togglesplit
+  hyprctl keyword general:layout dwindle
+  # SUPER+J/K are global and set in keybinds.conf; only manage SUPER+O here
+  hyprctl keyword bind SUPER,O,togglesplit
   notify-send -e -u low -i "$notif" " Dwindle Layout"
-	;;
+  ;;
 "dwindle")
-	hyprctl keyword general:layout master
-	# Drop togglesplit binding on SUPER+O when switching back to master
-	hyprctl keyword unbind SUPER,O
+  hyprctl keyword general:layout master
+  # Drop togglesplit binding on SUPER+O when switching back to master
+  hyprctl keyword unbind SUPER,O
   notify-send -e -u low -i "$notif" " Master Layout"
-	;;
+  ;;
 *) ;;
 
 esac


### PR DESCRIPTION
# Pull Request

## Description

Please read these instructions and remove unnecessary text.

- Bind global super, {J,K} in keybinds.conf and remove keybindslayout.sh execution from startup_apps.conf fixing the mentioned bug and simplifying the configuration.
- Fixes #888

## Type of change

Please put an `x` in the boxes that apply:

- [x ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x ] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x ] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
