### PR TITLE
Fixed SwitchKeyboardLayout was sourcing wrong file

### DIFF
--- a/config/hypr/scripts/SwitchKeyboardLayout.sh
+++ b/config/hypr/scripts/SwitchKeyboardLayout.sh
@@ -3,24 +3,23 @@
 # This is for changing kb_layouts. Set kb_layouts in $settings_file
 
 layout_file="$HOME/.cache/kb_layout"
-settings_file="$HOME/.config/hypr/UserConfigs/UserSettings.conf"
+settings_file="$HOME/.config/hypr/configs/SystemSettings.conf"
 notif_icon="$HOME/.config/swaync/images/ja.png"
 
 # Refined ignore list with patterns or specific device names
 ignore_patterns=(
-  "--(avrcp)" 
-  "Bluetooth Speaker" 
+  "--(avrcp)"
+  "Bluetooth Speaker"
   "Other Device 
   Name"
-  )
-
+)
 
 # Create layout file with default layout if it does not exist
 if [ ! -f "$layout_file" ]; then
   echo "Creating layout file..."
   default_layout=$(grep 'kb_layout = ' "$settings_file" | cut -d '=' -f 2 | tr -d '[:space:]' | cut -d ',' -f 1 2>/dev/null)
   default_layout=${default_layout:-"us"} # Default to 'us' layout
-  echo "$default_layout" > "$layout_file"
+  echo "$default_layout" >"$layout_file"
   echo "Default layout set to $default_layout"
 fi
 
@@ -32,7 +31,7 @@ if [ -f "$settings_file" ]; then
   kb_layout_line=$(grep 'kb_layout = ' "$settings_file" | cut -d '=' -f 2)
   # Remove leading and trailing spaces around each layout
   kb_layout_line=$(echo "$kb_layout_line" | tr -d '[:space:]')
-  IFS=',' read -r -a layout_mapping <<< "$kb_layout_line"
+  IFS=',' read -r -a layout_mapping <<<"$kb_layout_line"
 else
   echo "Settings file not found!"
   exit 1
@@ -49,56 +48,56 @@ for ((i = 0; i < layout_count; i++)); do
   fi
 done
 
-next_index=$(( (current_index + 1) % layout_count ))
+next_index=$(((current_index + 1) % layout_count))
 new_layout="${layout_mapping[next_index]}"
 echo "Next layout: $new_layout"
 
 # Function to get keyboard names
 get_keyboard_names() {
-    hyprctl devices -j | jq -r '.keyboards[].name'
+  hyprctl devices -j | jq -r '.keyboards[].name'
 }
 
 # Function to check if a device matches any ignore pattern
 is_ignored() {
-    local device_name=$1
-    for pattern in "${ignore_patterns[@]}"; do
-        if [[ "$device_name" == *"$pattern"* ]]; then
-            return 0 # Device matches ignore pattern
-        fi
-    done
-    return 1 # Device does not match any ignore pattern
+  local device_name=$1
+  for pattern in "${ignore_patterns[@]}"; do
+    if [[ "$device_name" == *"$pattern"* ]]; then
+      return 0 # Device matches ignore pattern
+    fi
+  done
+  return 1 # Device does not match any ignore pattern
 }
 
 # Function to change keyboard layout
 change_layout() {
-    local error_found=false
+  local error_found=false
 
-    while read -r name; do
-        if is_ignored "$name"; then
-            echo "Skipping ignored device: $name"
-            continue
-        fi
-        
-        echo "Switching layout for $name to $new_layout..."
-	      hyprctl switchxkblayout "$name" "$next_index"
-        if [ $? -ne 0 ]; then
-            echo "Error while switching layout for $name." >&2
-            error_found=true
-        fi
-    done <<< "$(get_keyboard_names)"
+  while read -r name; do
+    if is_ignored "$name"; then
+      echo "Skipping ignored device: $name"
+      continue
+    fi
 
-    $error_found && return 1
-    return 0
+    echo "Switching layout for $name to $new_layout..."
+    hyprctl switchxkblayout "$name" "$next_index"
+    if [ $? -ne 0 ]; then
+      echo "Error while switching layout for $name." >&2
+      error_found=true
+    fi
+  done <<<"$(get_keyboard_names)"
+
+  $error_found && return 1
+  return 0
 }
 
 # Execute layout change and notify
 if ! change_layout; then
-    notify-send -u low -t 2000 'kb_layout' " Error:" " Layout change failed"
-    echo "Layout change failed." >&2
-    exit 1
+  notify-send -u low -t 2000 'kb_layout' " Error:" " Layout change failed"
+  echo "Layout change failed." >&2
+  exit 1
 else
-    notify-send -u low -i "$notif_icon" " kb_layout: $new_layout"
-    echo "Layout change notification sent."
+  notify-send -u low -i "$notif_icon" " kb_layout: $new_layout"
+  echo "Layout change notification sent."
 fi
 
-echo "$new_layout" > "$layout_file"
+echo "$new_layout" >"$layout_file"

--- a/config/hypr/scripts/Tak0-Per-Window-Switch.sh
+++ b/config/hypr/scripts/Tak0-Per-Window-Switch.sh
@@ -1,5 +1,5 @@
 ##################################################################
-#                                                                #   
+#                                                                #
 #                                                                #
 #                  TAK_0'S Per-Window-Switch                     #
 #                                                                #
@@ -7,21 +7,14 @@
 #                                                                #
 #  Just a little script that I made to switch keyboard layouts   #
 #       per-window instead of global switching for the more      #
-#                 smooth and comfortable workflow.               #  
+#                 smooth and comfortable workflow.               #
 #                                                                #
 ##################################################################
 
-
-
-
-
-
-
-
-# This is for changing kb_layouts. Set kb_layouts in 
+# This is for changing kb_layouts. Set kb_layouts in
 
 MAP_FILE="$HOME/.cache/kb_layout_per_window"
-CFG_FILE="$HOME/.config/hypr/UserConfigs/UserSettings.conf"
+CFG_FILE="$HOME/.config/hypr/configs/SystemSettings.conf"
 ICON="$HOME/.config/swaync/images/ja.png"
 SCRIPT_NAME="$(basename "$0")"
 
@@ -49,8 +42,8 @@ get_keyboards() {
 # Save window-specific layout
 save_map() {
   local W=$1 L=$2
-  grep -v "^${W}:" "$MAP_FILE" > "$MAP_FILE.tmp"
-  echo "${W}:${L}" >> "$MAP_FILE.tmp"
+  grep -v "^${W}:" "$MAP_FILE" >"$MAP_FILE.tmp"
+  echo "${W}:${L}" >>"$MAP_FILE.tmp"
   mv "$MAP_FILE.tmp" "$MAP_FILE"
 }
 
@@ -82,7 +75,7 @@ cmd_toggle() {
       break
     fi
   done
-  NEXT=$(( (i+1) % count ))
+  NEXT=$(((i + 1) % count))
   do_switch "$NEXT"
   save_map "$W" "${kb_layouts[NEXT]}"
   notify-send -u low -i "$ICON" "kb_layout: ${kb_layouts[NEXT]}"
@@ -104,7 +97,10 @@ cmd_restore() {
 # Listen to focus events and restore window-specific layouts
 subscribe() {
   local SOCKET2="$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock"
-  [[ -S "$SOCKET2" ]] || { echo "Error: Hyprland socket not found." >&2; exit 1; }
+  [[ -S "$SOCKET2" ]] || {
+    echo "Error: Hyprland socket not found." >&2
+    exit 1
+  }
 
   socat -u UNIX-CONNECT:"$SOCKET2" - | while read -r line; do
     [[ "$line" =~ ^activewindow ]] && cmd_restore
@@ -118,6 +114,9 @@ fi
 
 # CLI
 case "$1" in
-  toggle|"") cmd_toggle ;;
-  *) echo "Usage: $SCRIPT_NAME [toggle]" >&2; exit 1 ;;
+toggle | "") cmd_toggle ;;
+*)
+  echo "Usage: $SCRIPT_NAME [toggle]" >&2
+  exit 1
+  ;;
 esac


### PR DESCRIPTION

# Pull Request

## Description

 With v2.3.18 we moved some files from User to System.  kb_layout switch was looking UserSettings still 

 Changes to be committed:
	modified:   config/hypr/scripts/SwitchKeyboardLayout.sh
	modified:   config/hypr/scripts/Tak0-Per-Window-Switch.sh

## Type of change

Please put an `x` in the boxes that apply:

- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have tested my code locally and it works as expected.
