### PR TITLE
Fix: Update wallpaper path in WallustSwww.sh

### DIFF
--- a/config/hypr/scripts/WallustSwww.sh
+++ b/config/hypr/scripts/WallustSwww.sh
@@ -40,7 +40,8 @@ else
   if [[ -f "$cache_file" ]]; then
     # The first non-filter line is the original wallpaper path
     # wallpaper_path="$(grep -v 'Lanczos3' "$cache_file" | head -n 1)"
-    wallpaper_path=$(swww query | grep $current_monitor | awk '{print $9}')
+    # wallpaper_path=$(swww query | grep $current_monitor | awk '{print $9}')
+    wallpaper_path=$(swww query | sed 's/.*image: //')
   fi
 fi
 


### PR DESCRIPTION
# Fix: Update wallpaper path in WallustSwww.sh

## Update swww function of wallpaper_path to match newest swww version.

- In the newer swww versions the old function/command doesnt work anymore and will only return the monitor ID. This change added a working function and is tested in Fedora.
- This will fix the wallust auto color panel and the ~/.config/rofi/.current_wallpaper file updating 
    - hyprlock will use the right wallpaper after fixing the ~/.config/rofi/.current_wallpaper 
    - the window boarder will update depending on the wallpaper
    - the rofi embed wallpaper sections will now match the current wallpaper
- It is only a small fix changing the swww function 
- I was just customizing my fedora x hyprland setup (installed with your Fedora x Hyprland repo) and found that bug. 

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist


- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Additional context

I was just customizing my personal Fedora x Hyprland setup and then I realized while customizing rofi, that the ~/.config/rofi/.current_wallpaper file isn't updating while changing the wallpaper. Then I went debugging and found out that the old command of the variable "wallpaper_path" in WallustSwww.sh is only returning the ID of the monitor or an error 

``` Usage: grep [OPTION]... PATTERNS [FILE]...
Try 'grep --help' for more information.

thread 'main' (486303) panicked at library/std/src/io/stdio.rs:1165:9:
failed printing to stdout: Broken pipe (os error 32)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace 
```

so I tried to only run `swww query` instead of `swww query | grep $current_monitor | awk '{print $9}'` and then filter the path of the wallpaper. And just like that I got to my simple fix. 