### PR TITLE
Add theme switcher help shortcut

### DIFF
--- a/config/hypr/scripts/ThemeChanger.sh
+++ b/config/hypr/scripts/ThemeChanger.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # SPDX-FileCopyrightText: 2025-present Ahum Maitra theahummaitra@gmail.com
 #
 # SPDX-License-Identifier: 	GPL-3.0-or-later
@@ -7,9 +9,10 @@
 # Repository url : https://github.com/TheAhumMaitra/cautious-waddle
 
 # User choice
-choice=$(wallust theme list |
-  sed '1d; s/^- //' |
-  rofi -dmenu -p "Select Global Theme")
+choice=$(wallust theme list \
+  | sed '1d' \
+  | sed 's/^- //' \
+  | rofi -dmenu -p "Select Global Theme")
 
 # If user requested to exit, then exit
 [[ -z "$choice" ]] && exit 0
@@ -18,7 +21,7 @@ choice=$(wallust theme list |
 wallust theme "$choice"
 
 # Inform user about theme changed
-notify-send "Global theme changed" "Theme selcted $choice"
+notify-send "Global theme changed" "Global Theme selected $choice"
 
 # Give warning to user for Waybar theme refresh
 notify-send "Press SUPER+ALT+R to Refresh Waybar Theme"


### PR DESCRIPTION
# Add theme switcher help shortcut

## Description

Recently a new feature contributed by me merged into the `development` branch. It is a theme switcher for Kool's Hyprland, which can be launched via pressing `SUPER +T`. I want to add the shortcut on the help sheet.

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [x] **Other** (enhancement)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.


**Have a nice day!**