### PR TITLE
Moved the 0.53 spec WindowRules file to default WindowRules.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## FIXES:
 
+- Updated: Made the WindowRules file for 0.53+ the default
+  - There are more distros now running 0.53.1 vs. earlier versions
+  - The older file is still there for those users not yet up to date
 - Fixed: Opacity for `vscode` configured multiple times
 - Fixed: Quickshell `overview` not working, error "Quickshell or AGS not installed"
   - If `shell.qml` exists in `~/.config/quickshell` that blocks overview

--- a/config/hypr/configs/WindowRules-pre-53.conf
+++ b/config/hypr/configs/WindowRules-pre-53.conf
@@ -1,0 +1,231 @@
+# /* ---- 💫 https://github.com/JaKooLit 💫 ---- */  #
+# Vendor defaults for window rules and layerrules
+# See https://wiki.hyprland.org/Configuring/Window-Rules/ for more
+
+# NOTES: This is only for Hyprland > 0.48
+
+# note for ja: This should NOT be implemented on Debian and Ubuntu
+
+# windowrule - tags - add apps under appropriate tag to use the same settings
+# browser tags
+windowrule = tag +browser, class:^([Ff]irefox|org.mozilla.firefox|[Ff]irefox-esr|[Ff]irefox-bin)$
+windowrule = tag +browser, class:^([Gg]oogle-chrome(-beta|-dev|-unstable)?)$
+windowrule = tag +browser, class:^(chrome-.+-Default)$ # Chrome PWAs
+windowrule = tag +browser, class:^([Cc]hromium)$
+windowrule = tag +browser, class:^([Mm]icrosoft-edge(-stable|-beta|-dev|-unstable))$
+windowrule = tag +browser, class:^(Brave-browser(-beta|-dev|-unstable)?)$
+windowrule = tag +browser, class:^([Tt]horium-browser|[Cc]achy-browser)$
+windowrule = tag +browser, class:^(zen-alpha|zen)$
+
+# notif tags
+windowrule = tag +notif, class:^(swaync-control-center|swaync-notification-window|swaync-client|class)$
+
+# KooL settings tag
+windowrule = tag +KooL_Cheat, title:^(KooL Quick Cheat Sheet)$
+windowrule = tag +KooL_Settings, title:^(KooL Hyprland Settings)$
+windowrule = tag +KooL-Settings, class:^(nwg-displays|nwg-look)$
+
+# terminal tags
+windowrule = tag +terminal, class:^(Alacritty|kitty|kitty-dropterm)$
+
+# email tags
+windowrule = tag +email, class:^([Tt]hunderbird|org.gnome.Evolution)$
+windowrule = tag +email, class:^(eu.betterbird.Betterbird)$
+
+# project tags
+windowrule = tag +projects, class:^(codium|codium-url-handler|VSCodium)$
+windowrule = tag +projects, class:^(VSCode|code|code-url-handler)$
+windowrule = tag +projects, class:^(jetbrains-.+)$ # JetBrains IDEs
+
+# screenshare tags
+windowrule = tag +screenshare, class:^(com.obsproject.Studio)$
+
+# IM tags
+windowrule = tag +im, class:^([Dd]iscord|[Ww]ebCord|[Vv]esktop)$
+windowrule = tag +im, class:^([Ff]erdium)$
+windowrule = tag +im, class:^([Ww]hatsapp-for-linux)$
+windowrule = tag +im, class:^(ZapZap|com.rtosta.zapzap)$
+windowrule = tag +im, class:^(org.telegram.desktop|io.github.tdesktop_x64.TDesktop)$
+windowrule = tag +im, class:^(teams-for-linux)$
+windowrule = tag +im, class:^(im.riot.Riot|Element)$ # Element Matrix client
+
+# game tags
+windowrule = tag +games, class:^(gamescope)$
+windowrule = tag +games, class:^(steam_app_\d+)$
+
+# gamestore tags
+windowrule = tag +gamestore, class:^([Ss]team)$
+windowrule = tag +gamestore, title:^([Ll]utris)$
+windowrule = tag +gamestore, class:^(com.heroicgameslauncher.hgl)$
+
+# file-manager tags
+windowrule = tag +file-manager, class:^([Tt]hunar|org.gnome.Nautilus|[Pp]cmanfm-qt)$
+windowrule = tag +file-manager, class:^(app.drey.Warp)$
+
+# wallpaper tags
+windowrule = tag +wallpaper, class:^([Ww]aytrogen)$
+
+# multimedia tags
+windowrule = tag +multimedia, class:^([Aa]udacious)$
+
+# multimedia-video tags
+windowrule = tag +multimedia_video, class:^([Mm]pv|vlc)$
+
+# settings tags
+windowrule = tag +settings, title:^(ROG Control)$
+windowrule = tag +settings, class:^(wihotspot(-gui)?)$ # wifi hotspot
+windowrule = tag +settings, class:^([Bb]aobab|org.gnome.[Bb]aobab)$ # Disk usage analyzer
+windowrule = tag +settings, class:^(gnome-disks|wihotspot(-gui)?)$
+windowrule = tag +settings, title:(Kvantum Manager)
+windowrule = tag +settings, class:^(file-roller|org.gnome.FileRoller)$ # archive manager
+windowrule = tag +settings, class:^(nm-applet|nm-connection-editor|blueman-manager)$
+windowrule = tag +settings, class:^(pavucontrol|org.pulseaudio.pavucontrol|com.saivert.pwvucontrol)$
+windowrule = tag +settings, class:^(qt5ct|qt6ct|[Yy]ad)$
+windowrule = tag +settings, class:(xdg-desktop-portal-gtk)
+windowrule = tag +settings, class:^(org.kde.polkit-kde-authentication-agent-1)$
+windowrule = tag +settings, class:^([Rr]ofi)$
+
+# viewer tags
+windowrule = tag +viewer, class:^(gnome-system-monitor|org.gnome.SystemMonitor|io.missioncenter.MissionCenter)$ # system monitor
+windowrule = tag +viewer, class:^(evince)$ # document viewer 
+windowrule = tag +viewer, class:^(eog|org.gnome.Loupe)$ # image viewer
+
+# Some special override rules
+windowrule = noblur, tag:multimedia_video*
+windowrule = opacity 1.0, tag:multimedia_video*
+ 
+# POSITION
+# windowrule = center,floating:1 # warning, it cause even the menu to float and center.
+windowrule = center, tag:KooL_Cheat*
+windowrule = center, class:([Tt]hunar), title:negative:(.*[Tt]hunar.*)
+windowrule = center, title:^(ROG Control)$
+windowrule = center, tag:KooL-Settings*
+windowrule = center, title:^(Keybindings)$
+windowrule = center, class:^(pavucontrol|org.pulseaudio.pavucontrol|com.saivert.pwvucontrol)$
+windowrule = center, class:^([Ww]hatsapp-for-linux|ZapZap|com.rtosta.zapzap)$
+windowrule = center, class:^([Ff]erdium)$
+windowrule = move 72% 7%,title:^(Picture-in-Picture)$ 
+#windowrule = move 72% 7%,title:^(Firefox)$ 
+
+# windowrule to avoid idle for fullscreen apps
+#windowrule = idleinhibit fullscreen, class:^(*)$
+#windowrule = idleinhibit fullscreen, title:^(*)$
+windowrule = idleinhibit fullscreen, fullscreen:1
+
+# windowrule move to workspace
+#windowrule = workspace 1, tag:email*
+#windowrule = workspace 2, tag:browser*
+#windowrule = workspace 3, class:^([Tt]hunar)$
+#windowrule = workspace 3, tag:projects*
+#windowrule = workspace 5, tag:gamestore*
+#windowrule = workspace 7, tag:im*
+#windowrule = workspace 8, tag:games*
+
+# windowrule move to workspace (silent)
+#windowrule = workspace 4 silent, tag:screenshare*
+#windowrule = workspace 6 silent, class:^(virt-manager)$
+#windowrule = workspace 6 silent, class:^(.virt-manager-wrapped)$
+#windowrule = workspace 9 silent, tag:multimedia*
+#
+# FLOAT
+windowrule = float, tag:KooL_Cheat*
+windowrule = float, tag:wallpaper*
+windowrule = float, tag:settings*
+windowrule = float, tag:viewer*
+windowrule = float, tag:KooL-Settings*
+windowrule = float, class:([Zz]oom|onedriver|onedriver-launcher)$
+windowrule = float, class:(org.gnome.Calculator), title:(Calculator)
+windowrule = float, class:^(mpv|com.github.rafostar.Clapper)$
+windowrule = float, class:^([Qq]alculate-gtk)$
+#windowrule = float, class:^([Ww]hatsapp-for-linux|ZapZap|com.rtosta.zapzap)$
+windowrule = float, class:^([Ff]erdium)$
+windowrule = float, title:^(Picture-in-Picture)$
+#windowrule = float, title:^(Firefox)$
+
+# windowrule - ######### float popups and dialogue #######
+windowrule = float, title:^(Authentication Required)$
+windowrule = center, title:^(Authentication Required)$
+windowrule = float, class:(codium|codium-url-handler|VSCodium), title:negative:(.*codium.*|.*VSCodium.*)
+windowrule = float, class:^(com.heroicgameslauncher.hgl)$, title:negative:(Heroic Games Launcher)
+windowrule = float, class:^([Ss]team)$, title:negative:^([Ss]team)$
+windowrule = float, class:([Tt]hunar), title:negative:(.*[Tt]hunar.*)
+
+windowrule = float, title:^(Add Folder to Workspace)$
+windowrule = size 70% 60%, title:^(Add Folder to Workspace)$
+windowrule = center, title:^(Add Folder to Workspace)$
+
+windowrule = float, title:^(Save As)$
+windowrule = size 70% 60%, title:^(Save As)$
+windowrule = center, title:^(Save As)$
+
+windowrule = float, initialTitle:(Open Files)
+windowrule = size 70% 60%, initialTitle:(Open Files)
+
+windowrule = float, title:^(SDDM Background)$ #KooL's Dots YAD for setting SDDM background
+windowrule = center, title:^(SDDM Background)$ #KooL's Dots YAD for setting SDDM background
+windowrule = size 16% 12%, title:^(SDDM Background)$ #KooL's Dots YAD for setting SDDM background
+# END of float popups and dialogue #######
+
+# OPACITY
+windowrule = opacity 0.99 0.8, tag:browser*
+windowrule = opacity 0.9 0.8, tag:projects*
+windowrule = opacity 0.94 0.86, tag:im*
+windowrule = opacity 0.94 0.86, tag:multimedia*
+windowrule = opacity 0.9 0.8, tag:file-manager*
+windowrule = opacity 0.9 0.7, tag:terminal*
+windowrule = opacity 0.8 0.7, tag:settings*
+windowrule = opacity 0.82 0.75, tag:viewer*
+windowrule = opacity 0.9 0.7, tag:wallpaper*
+windowrule = opacity 0.8 0.7, class:^(gedit|org.gnome.TextEditor|mousepad)$
+windowrule = opacity 0.9 0.8, class:^(deluge)$
+windowrule = opacity 0.9 0.8, class:^(seahorse)$ # gnome-keyring gui
+windowrule = opacity 0.95 0.75, title:^(Picture-in-Picture)$
+
+# SIZE
+windowrule = size 65% 90%, tag:KooL_Cheat*
+windowrule = size 70% 70%, tag:wallpaper*
+windowrule = size 70% 70%, tag:settings*
+windowrule = size 60% 70%, class:^([Ww]hatsapp-for-linux|ZapZap|com.rtosta.zapzap)$
+windowrule = size 60% 70%, class:^([Ff]erdium)$
+
+#windowrule = size 25% 25%, title:^(Picture-in-Picture)$   
+#windowrule = size 25% 25%, title:^(Firefox)$ 
+
+# PINNING
+windowrule = pin, title:^(Picture-in-Picture)$
+#windowrule = pin,title:^(Firefox)$ 
+
+# windowrule - extras
+windowrule = keepaspectratio, title:^(Picture-in-Picture)$
+
+# BLUR & FULLSCREEN
+windowrule = noblur, tag:games*
+windowrule = fullscreen, tag:games*
+
+
+#This not gonna take the focus to the window that appears when hovering over some of the parts of the IntelliJ Products 
+windowrule = noinitialfocus, class:^(jetbrains-*)
+windowrule = noinitialfocus, title:^(wind.*)$
+
+#windowrule = bordercolor rgb(EE4B55) rgb(880808), fullscreen:1
+#windowrule = bordercolor rgb(282737) rgb(1E1D2D), floating:1
+#windowrule = opacity 0.8 0.8, pinned:1
+
+# LAYER RULES
+layerrule = blur, rofi
+layerrule = ignorezero, rofi
+layerrule = blur, notifications
+layerrule = ignorezero, notifications
+layerrule = blur, quickshell:overview
+layerrule = ignorezero, quickshell:overview
+layerrule = ignorealpha 0.5, quickshell:overview
+
+#layerrule = ignorealpha 0.5, tag:notif*
+
+#layerrule = ignorezero, class:^([Rr]ofi)$
+#layerrule = blur, class:^([Rr]ofi)$
+#layerrule = unset,class:^([Rr]ofi)$
+#layerrule = ignorezero, <rofi>
+
+#layerrule = ignorezero, overview
+#layerrule = blur, overview

--- a/config/hypr/configs/WindowRules.conf
+++ b/config/hypr/configs/WindowRules.conf
@@ -2,230 +2,179 @@
 # Vendor defaults for window rules and layerrules
 # See https://wiki.hyprland.org/Configuring/Window-Rules/ for more
 
-# NOTES: This is only for Hyprland > 0.48
-
+# NOTES: This is only for Hyprland > 0.52.1
 # note for ja: This should NOT be implemented on Debian and Ubuntu
 
 # windowrule - tags - add apps under appropriate tag to use the same settings
 # browser tags
-windowrule = tag +browser, class:^([Ff]irefox|org.mozilla.firefox|[Ff]irefox-esr|[Ff]irefox-bin)$
-windowrule = tag +browser, class:^([Gg]oogle-chrome(-beta|-dev|-unstable)?)$
-windowrule = tag +browser, class:^(chrome-.+-Default)$ # Chrome PWAs
-windowrule = tag +browser, class:^([Cc]hromium)$
-windowrule = tag +browser, class:^([Mm]icrosoft-edge(-stable|-beta|-dev|-unstable))$
-windowrule = tag +browser, class:^(Brave-browser(-beta|-dev|-unstable)?)$
-windowrule = tag +browser, class:^([Tt]horium-browser|[Cc]achy-browser)$
-windowrule = tag +browser, class:^(zen-alpha|zen)$
+windowrule = match:class ^([Ff]irefox|org.mozilla.firefox|[Ff]irefox-esr|[Ff]irefox-bin)$, tag +browser
+windowrule = match:class ^([Gg]oogle-chrome(-beta|-dev|-unstable)?)$, tag +browser
+windowrule = match:class ^(chrome-.+-Default)$, tag +browser
+windowrule = match:class ^([Cc]hromium)$, tag +browser
+windowrule = match:class ^([Mm]icrosoft-edge(-stable|-beta|-dev|-unstable))$, tag +browser
+windowrule = match:class ^(Brave-browser(-beta|-dev|-unstable)?)$, tag +browser
+windowrule = match:class ^([Tt]horium-browser|[Cc]achy-browser)$, tag +browser
+windowrule = match:class ^(zen-alpha|zen)$, tag +browser
 
 # notif tags
-windowrule = tag +notif, class:^(swaync-control-center|swaync-notification-window|swaync-client|class)$
+windowrule = match:class ^(swaync-control-center|swaync-notification-window|swaync-client|class)$, tag +notif
 
 # KooL settings tag
-windowrule = tag +KooL_Cheat, title:^(KooL Quick Cheat Sheet)$
-windowrule = tag +KooL_Settings, title:^(KooL Hyprland Settings)$
-windowrule = tag +KooL-Settings, class:^(nwg-displays|nwg-look)$
+windowrule = match:title ^(KooL Quick Cheat Sheet)$, tag +KooL_Cheat
+windowrule = match:title ^(KooL Hyprland Settings)$, tag +KooL_Settings
+windowrule = match:class ^(nwg-displays|nwg-look)$, tag +KooL-Settings
 
 # terminal tags
-windowrule = tag +terminal, class:^(Alacritty|kitty|kitty-dropterm)$
+windowrule = match:class ^(Alacritty|kitty|kitty-dropterm)$, tag +terminal
 
 # email tags
-windowrule = tag +email, class:^([Tt]hunderbird|org.gnome.Evolution)$
-windowrule = tag +email, class:^(eu.betterbird.Betterbird)$
+windowrule = match:class ^([Tt]hunderbird|org.gnome.Evolution)$, tag +email
+windowrule = match:class ^(eu.betterbird.Betterbird)$, tag +email
 
 # project tags
-windowrule = tag +projects, class:^(codium|codium-url-handler|VSCodium)$
-windowrule = tag +projects, class:^(VSCode|code|code-url-handler)$
-windowrule = tag +projects, class:^(jetbrains-.+)$ # JetBrains IDEs
+windowrule = match:class ^(codium|codium-url-handler|VSCodium)$, tag +projects
+windowrule = match:class ^(VSCode|code|code-url-handler)$, tag +projects
+windowrule = match:class ^(jetbrains-.+)$, tag +projects
 
 # screenshare tags
-windowrule = tag +screenshare, class:^(com.obsproject.Studio)$
+windowrule = match:class ^(com.obsproject.Studio)$, tag +screenshare
 
 # IM tags
-windowrule = tag +im, class:^([Dd]iscord|[Ww]ebCord|[Vv]esktop)$
-windowrule = tag +im, class:^([Ff]erdium)$
-windowrule = tag +im, class:^([Ww]hatsapp-for-linux)$
-windowrule = tag +im, class:^(ZapZap|com.rtosta.zapzap)$
-windowrule = tag +im, class:^(org.telegram.desktop|io.github.tdesktop_x64.TDesktop)$
-windowrule = tag +im, class:^(teams-for-linux)$
-windowrule = tag +im, class:^(im.riot.Riot|Element)$ # Element Matrix client
+windowrule = match:class ^([Dd]iscord|[Ww]ebCord|[Vv]esktop)$, tag +im
+windowrule = match:class ^([Ff]erdium)$, tag +im
+windowrule = match:class ^([Ww]hatsapp-for-linux)$, tag +im
+windowrule = match:class ^(ZapZap|com.rtosta.zapzap)$, tag +im
+windowrule = match:class ^(org.telegram.desktop|io.github.tdesktop_x64.TDesktop)$, tag +im
+windowrule = match:class ^(teams-for-linux)$, tag +im
+windowrule = match:class ^(im.riot.Riot|Element)$, tag +im
 
 # game tags
-windowrule = tag +games, class:^(gamescope)$
-windowrule = tag +games, class:^(steam_app_\d+)$
+windowrule = match:class ^(gamescope)$, tag +games
+windowrule = match:class ^(steam_app_\\d+)$, tag +games
 
 # gamestore tags
-windowrule = tag +gamestore, class:^([Ss]team)$
-windowrule = tag +gamestore, title:^([Ll]utris)$
-windowrule = tag +gamestore, class:^(com.heroicgameslauncher.hgl)$
+windowrule = match:class ^([Ss]team)$, tag +gamestore
+windowrule = match:title ^([Ll]utris)$, tag +gamestore
+windowrule = match:class ^(com.heroicgameslauncher.hgl)$, tag +gamestore
 
 # file-manager tags
-windowrule = tag +file-manager, class:^([Tt]hunar|org.gnome.Nautilus|[Pp]cmanfm-qt)$
-windowrule = tag +file-manager, class:^(app.drey.Warp)$
+windowrule = match:class ^([Tt]hunar|org.gnome.Nautilus|[Pp]cmanfm-qt)$, tag +file-manager
+windowrule = match:class ^(app.drey.Warp)$, tag +file-manager
 
 # wallpaper tags
-windowrule = tag +wallpaper, class:^([Ww]aytrogen)$
+windowrule = match:class ^([Ww]aytrogen)$, tag +wallpaper
 
 # multimedia tags
-windowrule = tag +multimedia, class:^([Aa]udacious)$
+windowrule = match:class ^([Aa]udacious)$, tag +multimedia
 
 # multimedia-video tags
-windowrule = tag +multimedia_video, class:^([Mm]pv|vlc)$
+windowrule = match:class ^([Mm]pv|vlc)$, tag +multimedia_video
 
 # settings tags
-windowrule = tag +settings, title:^(ROG Control)$
-windowrule = tag +settings, class:^(wihotspot(-gui)?)$ # wifi hotspot
-windowrule = tag +settings, class:^([Bb]aobab|org.gnome.[Bb]aobab)$ # Disk usage analyzer
-windowrule = tag +settings, class:^(gnome-disks|wihotspot(-gui)?)$
-windowrule = tag +settings, title:(Kvantum Manager)
-windowrule = tag +settings, class:^(file-roller|org.gnome.FileRoller)$ # archive manager
-windowrule = tag +settings, class:^(nm-applet|nm-connection-editor|blueman-manager)$
-windowrule = tag +settings, class:^(pavucontrol|org.pulseaudio.pavucontrol|com.saivert.pwvucontrol)$
-windowrule = tag +settings, class:^(qt5ct|qt6ct|[Yy]ad)$
-windowrule = tag +settings, class:(xdg-desktop-portal-gtk)
-windowrule = tag +settings, class:^(org.kde.polkit-kde-authentication-agent-1)$
-windowrule = tag +settings, class:^([Rr]ofi)$
+windowrule = match:title ^(ROG Control)$, tag +settings
+windowrule = match:class ^(wihotspot(-gui)?)$, tag +settings
+windowrule = match:class ^([Bb]aobab|org.gnome.[Bb]aobab)$, tag +settings
+windowrule = match:class ^(gnome-disks|wihotspot(-gui)?)$, tag +settings
+windowrule = match:title (Kvantum Manager), tag +settings
+windowrule = match:class ^(file-roller|org.gnome.FileRoller)$, tag +settings
+windowrule = match:class ^(nm-applet|nm-connection-editor|blueman-manager)$, tag +settings
+windowrule = match:class ^(pavucontrol|org.pulseaudio.pavucontrol|com.saivert.pwvucontrol)$, tag +settings
+windowrule = match:class ^(qt5ct|qt6ct|[Yy]ad)$, tag +settings
+windowrule = match:class (xdg-desktop-portal-gtk), tag +settings
+windowrule = match:class ^(org.kde.polkit-kde-authentication-agent-1)$, tag +settings
+windowrule = match:class ^([Rr]ofi)$, tag +settings
 
 # viewer tags
-windowrule = tag +viewer, class:^(gnome-system-monitor|org.gnome.SystemMonitor|io.missioncenter.MissionCenter)$ # system monitor
-windowrule = tag +viewer, class:^(evince)$ # document viewer 
-windowrule = tag +viewer, class:^(eog|org.gnome.Loupe)$ # image viewer
+windowrule = match:class ^(gnome-system-monitor|org.gnome.SystemMonitor|io.missioncenter.MissionCenter)$, tag +viewer
+windowrule = match:class ^(evince)$, tag +viewer
+windowrule = match:class ^(eog|org.gnome.Loupe)$, tag +viewer
 
 # Some special override rules
-windowrule = noblur, tag:multimedia_video*
-windowrule = opacity 1.0, tag:multimedia_video*
- 
+windowrule = match:tag multimedia_video, no_blur on
+windowrule = match:tag multimedia_video, opacity 1.0
+
 # POSITION
-# windowrule = center,floating:1 # warning, it cause even the menu to float and center.
-windowrule = center, tag:KooL_Cheat*
-windowrule = center, class:([Tt]hunar), title:negative:(.*[Tt]hunar.*)
-windowrule = center, title:^(ROG Control)$
-windowrule = center, tag:KooL-Settings*
-windowrule = center, title:^(Keybindings)$
-windowrule = center, class:^(pavucontrol|org.pulseaudio.pavucontrol|com.saivert.pwvucontrol)$
-windowrule = center, class:^([Ww]hatsapp-for-linux|ZapZap|com.rtosta.zapzap)$
-windowrule = center, class:^([Ff]erdium)$
-windowrule = move 72% 7%,title:^(Picture-in-Picture)$ 
-#windowrule = move 72% 7%,title:^(Firefox)$ 
+# windowrule = match:floating true, center on
+windowrule = match:tag KooL_Cheat, center on
+windowrule = match:class ([Tt]hunar) match:title negative:(.*[Tt]hunar.*), center on
+windowrule = match:title ^(ROG Control)$, center on
+windowrule = match:tag KooL-Settings, center on
+windowrule = match:title ^(Keybindings)$, center on
+windowrule = match:class ^(pavucontrol|org.pulseaudio.pavucontrol|com.saivert.pwvucontrol)$, center on
+windowrule = match:class ^([Ww]hatsapp-for-linux|ZapZap|com.rtosta.zapzap)$, center on
+windowrule = match:class ^([Ff]erdium)$, center on
+windowrule = match:title ^(Picture-in-Picture)$, move 72% 7%
 
 # windowrule to avoid idle for fullscreen apps
-#windowrule = idleinhibit fullscreen, class:^(*)$
-#windowrule = idleinhibit fullscreen, title:^(*)$
-windowrule = idleinhibit fullscreen, fullscreen:1
+windowrule = match:fullscreen true, idle_inhibit fullscreen
 
-# windowrule move to workspace
-#windowrule = workspace 1, tag:email*
-#windowrule = workspace 2, tag:browser*
-#windowrule = workspace 3, class:^([Tt]hunar)$
-#windowrule = workspace 3, tag:projects*
-#windowrule = workspace 5, tag:gamestore*
-#windowrule = workspace 7, tag:im*
-#windowrule = workspace 8, tag:games*
-
-# windowrule move to workspace (silent)
-#windowrule = workspace 4 silent, tag:screenshare*
-#windowrule = workspace 6 silent, class:^(virt-manager)$
-#windowrule = workspace 6 silent, class:^(.virt-manager-wrapped)$
-#windowrule = workspace 9 silent, tag:multimedia*
-#
 # FLOAT
-windowrule = float, tag:KooL_Cheat*
-windowrule = float, tag:wallpaper*
-windowrule = float, tag:settings*
-windowrule = float, tag:viewer*
-windowrule = float, tag:KooL-Settings*
-windowrule = float, class:([Zz]oom|onedriver|onedriver-launcher)$
-windowrule = float, class:(org.gnome.Calculator), title:(Calculator)
-windowrule = float, class:^(mpv|com.github.rafostar.Clapper)$
-windowrule = float, class:^([Qq]alculate-gtk)$
-#windowrule = float, class:^([Ww]hatsapp-for-linux|ZapZap|com.rtosta.zapzap)$
-windowrule = float, class:^([Ff]erdium)$
-windowrule = float, title:^(Picture-in-Picture)$
-#windowrule = float, title:^(Firefox)$
+windowrule = match:tag KooL_Cheat, float on
+windowrule = match:tag wallpaper, float on
+windowrule = match:tag settings, float on
+windowrule = match:tag viewer, float on
+windowrule = match:tag KooL-Settings, float on
+windowrule = match:class ([Zz]oom|onedriver|onedriver-launcher), float on
+windowrule = match:class (org.gnome.Calculator) match:title (Calculator), float on
+windowrule = match:class ^(mpv|com.github.rafostar.Clapper)$, float on
+windowrule = match:class ^([Qq]alculate-gtk)$, float on
+windowrule = match:class ^([Ff]erdium)$, float on
+windowrule = match:title ^(Picture-in-Picture)$, float on
 
 # windowrule - ######### float popups and dialogue #######
-windowrule = float, title:^(Authentication Required)$
-windowrule = center, title:^(Authentication Required)$
-windowrule = float, class:(codium|codium-url-handler|VSCodium), title:negative:(.*codium.*|.*VSCodium.*)
-windowrule = float, class:^(com.heroicgameslauncher.hgl)$, title:negative:(Heroic Games Launcher)
-windowrule = float, class:^([Ss]team)$, title:negative:^([Ss]team)$
-windowrule = float, class:([Tt]hunar), title:negative:(.*[Tt]hunar.*)
+windowrule = match:title ^(Authentication Required)$, float on, center on
+windowrule = match:class (codium|codium-url-handler|VSCodium) match:title negative:(.*codium.*|.*VSCodium.*), float on
+windowrule = match:class ^(com.heroicgameslauncher.hgl)$ match:title negative:(Heroic Games Launcher), float on
+windowrule = match:class ^([Ss]team)$ match:title negative:^([Ss]team)$, float on
+windowrule = match:class ([Tt]hunar) match:title negative:(.*[Tt]hunar.*), float on
 
-windowrule = float, title:^(Add Folder to Workspace)$
-windowrule = size 70% 60%, title:^(Add Folder to Workspace)$
-windowrule = center, title:^(Add Folder to Workspace)$
+windowrule = match:title ^(Add Folder to Workspace)$, float on, size (monitor_w*0.7) (monitor_h*0.6), center on
 
-windowrule = float, title:^(Save As)$
-windowrule = size 70% 60%, title:^(Save As)$
-windowrule = center, title:^(Save As)$
+windowrule = match:title ^(Save As)$, float on, size (monitor_w*0.7) (monitor_h*0.6), center on
 
-windowrule = float, initialTitle:(Open Files)
-windowrule = size 70% 60%, initialTitle:(Open Files)
+windowrule = match:initial_title (Open Files), float on, size (monitor_w*0.7) (monitor_h*0.6)
 
-windowrule = float, title:^(SDDM Background)$ #KooL's Dots YAD for setting SDDM background
-windowrule = center, title:^(SDDM Background)$ #KooL's Dots YAD for setting SDDM background
-windowrule = size 16% 12%, title:^(SDDM Background)$ #KooL's Dots YAD for setting SDDM background
+windowrule = match:title ^(SDDM Background)$, float on, center on, size (monitor_w*0.16) (monitor_h*0.12)
+
+# YAD dialog for wallpaper confirmation
+windowrule = match:class ^(yad)$ match:title ^(YAD)$, float on, center on, size (monitor_w*0.2) (monitor_h*0.2)
 # END of float popups and dialogue #######
 
 # OPACITY
-windowrule = opacity 0.99 0.8, tag:browser*
-windowrule = opacity 0.9 0.8, tag:projects*
-windowrule = opacity 0.94 0.86, tag:im*
-windowrule = opacity 0.94 0.86, tag:multimedia*
-windowrule = opacity 0.9 0.8, tag:file-manager*
-windowrule = opacity 0.9 0.7, tag:terminal*
-windowrule = opacity 0.8 0.7, tag:settings*
-windowrule = opacity 0.82 0.75, tag:viewer*
-windowrule = opacity 0.9 0.7, tag:wallpaper*
-windowrule = opacity 0.8 0.7, class:^(gedit|org.gnome.TextEditor|mousepad)$
-windowrule = opacity 0.9 0.8, class:^(deluge)$
-windowrule = opacity 0.9 0.8, class:^(seahorse)$ # gnome-keyring gui
-windowrule = opacity 0.95 0.75, title:^(Picture-in-Picture)$
+windowrule = match:tag browser, opacity 0.99 0.8
+windowrule = match:tag projects, opacity 0.9 0.8
+windowrule = match:tag im, opacity 0.94 0.86
+windowrule = match:tag multimedia, opacity 0.94 0.86
+windowrule = match:tag file-manager, opacity 0.9 0.8
+windowrule = match:tag terminal, opacity 0.9 0.7
+windowrule = match:tag settings, opacity 0.8 0.7
+windowrule = match:tag viewer, opacity 0.82 0.75
+windowrule = match:tag wallpaper, opacity 0.9 0.7
+windowrule = match:class ^(gedit|org.gnome.TextEditor|mousepad)$, opacity 0.8 0.7
+windowrule = match:class ^(deluge)$, opacity 0.9 0.8
+windowrule = match:class ^(seahorse)$, opacity 0.9 0.8
+windowrule = match:title ^(Picture-in-Picture)$, opacity 0.95 0.75
 
 # SIZE
-windowrule = size 65% 90%, tag:KooL_Cheat*
-windowrule = size 70% 70%, tag:wallpaper*
-windowrule = size 70% 70%, tag:settings*
-windowrule = size 60% 70%, class:^([Ww]hatsapp-for-linux|ZapZap|com.rtosta.zapzap)$
-windowrule = size 60% 70%, class:^([Ff]erdium)$
-
-#windowrule = size 25% 25%, title:^(Picture-in-Picture)$   
-#windowrule = size 25% 25%, title:^(Firefox)$ 
+windowrule = match:tag KooL_Cheat, size (monitor_w*0.65) (monitor_h*0.9)
+windowrule = match:tag wallpaper, size (monitor_w*0.7) (monitor_h*0.7)
+windowrule = match:tag settings, size (monitor_w*0.7) (monitor_h*0.7)
+windowrule = match:class ^([Ww]hatsapp-for-linux|ZapZap|com.rtosta.zapzap)$, size (monitor_w*0.6) (monitor_h*0.7)
+windowrule = match:class ^([Ff]erdium)$, size (monitor_w*0.6) (monitor_h*0.7)
 
 # PINNING
-windowrule = pin, title:^(Picture-in-Picture)$
-#windowrule = pin,title:^(Firefox)$ 
-
-# windowrule - extras
-windowrule = keepaspectratio, title:^(Picture-in-Picture)$
+windowrule = match:title ^(Picture-in-Picture)$, pin on, keep_aspect_ratio on
 
 # BLUR & FULLSCREEN
-windowrule = noblur, tag:games*
-windowrule = fullscreen, tag:games*
+windowrule = match:tag games, no_blur on, fullscreen 0
+windowrule = match:tag games, fullscreen 0
 
-
-#This not gonna take the focus to the window that appears when hovering over some of the parts of the IntelliJ Products 
-windowrule = noinitialfocus, class:^(jetbrains-*)
-windowrule = noinitialfocus, title:^(wind.*)$
-
-#windowrule = bordercolor rgb(EE4B55) rgb(880808), fullscreen:1
-#windowrule = bordercolor rgb(282737) rgb(1E1D2D), floating:1
-#windowrule = opacity 0.8 0.8, pinned:1
+# This not gonna take the focus to the window that appears when hovering over some of the parts of the IntelliJ Products
+windowrule = match:class ^(jetbrains-*), no_initial_focus on
+windowrule = match:title ^(wind.*)$, no_initial_focus on
 
 # LAYER RULES
-layerrule = blur, rofi
-layerrule = ignorezero, rofi
-layerrule = blur, notifications
-layerrule = ignorezero, notifications
-layerrule = blur, quickshell:overview
-layerrule = ignorezero, quickshell:overview
-layerrule = ignorealpha 0.5, quickshell:overview
-
-#layerrule = ignorealpha 0.5, tag:notif*
-
-#layerrule = ignorezero, class:^([Rr]ofi)$
-#layerrule = blur, class:^([Rr]ofi)$
-#layerrule = unset,class:^([Rr]ofi)$
-#layerrule = ignorezero, <rofi>
-
-#layerrule = ignorezero, overview
-#layerrule = blur, overview
+layerrule = match:namespace rofi, blur on
+layerrule = match:namespace notifications, blur on
+layerrule = match:namespace quickshell:overview, blur on
+layerrule = match:namespace quickshell:overview, ignore_alpha 0.5


### PR DESCRIPTION

# Pull Request

## Description
There are more distros on 0.53.1 vs. earlier.
This will cut down on the number of support cases
We'll only have to deal with the few distros not yet updated

 On branch patch-windowrules
 Changes to be committed:
	modified:   CHANGELOG.mdhere are more distros on 0.53.1 vs. earlier.
This will cut down on the number of support cases
We'll only have to deal with the few distros not yet updated

 On branch patch-windowrules
 Changes to be committed:
	modified:   CHANGELOG.md
  new file:   config/hypr/configs/WindowRules-pre-53.conf
	modified:   config/hypr/configs/WindowRules.conf
  new file:   config/hypr/configs/WindowRules-pre-53.conf
	modified:   config/hypr/configs/WindowRules.conf
Please read these instructions and remove unnecessary text.
 
## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- 
## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
 - [x] I have tested my code locally and it works as expected.
 