### PR TITLE
fix(swaync): correct mpris album art size

### DIFF
--- a/config/swaync/config.json
+++ b/config/swaync/config.json
@@ -51,8 +51,8 @@
           "text": "Notification"
       },
       "mpris": {
-          "image-size": 10,
-          "image-radius": 0
+          "image-size": 96,
+          "image-radius": 8
       },
       "volume": {
           "label": "󰕾"


### PR DESCRIPTION
# Pull Request

## Description

This fixes a bug where the MPRIS widget album art in SwayNC appears as a tiny distorted vertical strip instead of displaying properly.

**Root cause:** The `image-size` in the mpris widget config was set to `10` pixels, which is far too small to display album artwork correctly.

**Solution:** Changed `image-size` from `10` to `96` pixels and added `image-radius: 8` for visual consistency with the rest of the UI's rounded corners.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Screenshots

**Before (image-size: 10):**

![before](https://github.com/user-attachments/assets/c311bd06-661b-4b74-973c-c281a0c708e4)

**After (image-size: 96):**

![after](https://github.com/user-attachments/assets/7d89fdb0-46b4-4c04-a219-77398188ac65)

## Additional context

The fix is minimal (2 value changes) and brings the MPRIS widget in line with typical album art sizing seen in other media player widgets.