### PR TITLE
Fixing discord link, server name change broke link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <a href="https://github.com/JaKooLit/Hyprland-Dots/wiki"><kbd> <br> Wiki <br> </kbd></a>&ensp;&ensp;
   <a href="https://github.com/JaKooLit/Hyprland-Dots/discussions"><kbd> <br> Discussions <br> </kbd></a>&ensp;&ensp;
   <a href="https://github.com/JaKooLit/Hyprland-Dots/wiki/Keybinds"><kbd> <br> Keybinds <br> </kbd></a>&ensp;&ensp;
-  <a href="https://discord.gg/kool-tech-world"><kbd> <br> Discord <br> </kbd></a>
+  <a href="https://discord.gg/RZJgC7KAKm"><kbd> <br> Discord <br> </kbd></a>
 </div><br>
 
 <div align="center">
@@ -89,7 +89,7 @@ sh <(curl -L https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/Distr
 ### 🪧 Attention 🪧
 
 - This repo does NOT contain or will NOT install any packages. These are only pre-configured-hyprland configs or dotfiles
-- refer to install scripts what packages needed to install... but atleast, Hyprland packages is needed 😏😏😏 duh!!
+- refer to install scripts what packages needed to install... but at least, Hyprland packages are required
 - This repo will be pulled by the Distro-Hyprland install scripts above if you opt to download pre-configured dots
 
 ### 👀 Screenshots 👀
@@ -118,7 +118,7 @@ cd Hyprland-Dots
 ```
 
 > to download from Development branch (development and testing)
-> Not recommeded for non-testing systems 
+> Not recommeded for non-testing systems
 
 ```bash
 git clone --depth=1 https://github.com/JaKooLit/Hyprland-Dots.git -b development
@@ -158,7 +158,7 @@ chmod +x upgrade.sh
 - Ubuntu 24.04/25.10
   - We are now using a PPA to get more current versions of Hyprland.
   - So the current version of these Dotfiles are compatible if you updated to the PPA based configuration.
-    
+
 #### ⚠️⚠️⚠️ ATTENTION - BACKUPS CREATED by SCRIPT
 
 > [!CAUTION]


### PR DESCRIPTION
# Pull Request

## Description
 
Fixing discord link  Server name change broke links.  
I renamed it back but hasn't been updated yet on discord 

https://discord.gg/RZJgC7KAKm
