### PR TITLE
Add SummitSplit v3 configuration for top and bottom bars

### DIFF
--- a/config/waybar/configs/[TOP & BOT] SummitSplit v3
+++ b/config/waybar/configs/[TOP & BOT] SummitSplit v3
@@ -1,0 +1,79 @@
+//Updated Sumsplit to include 0-JA-0 Top and updated BOT
+  [
+    {
+    "include": [
+    "$HOME/.config/waybar/Modules",
+    "$HOME/.config/waybar/ModulesWorkspaces",
+    "$HOME/.config/waybar/ModulesCustom",
+    "$HOME/.config/waybar/ModulesGroups",
+    "$HOME/.config/waybar/UserModules",
+    ],
+      "name": "topbar",
+      "layer": "top",
+      "position": "top",
+      //"mode": "dock",
+      "exclusive": true,
+      "spacing": 2,
+      "passthrough": false,
+      "gtk-layer-shell": true,
+      "reload_style_on_change": true,
+      "modules-left": [
+        "idle_inhibitor",
+        "custom/separator#blank",
+        "tray",
+        "connections",
+        "clock",
+        "network#speed",
+
+        "custom/separator#blank_2",
+      ],
+      "modules-center": ["group/app_drawer",
+      "custom/separator#dot-line",
+      "hyprland/workspaces#rw",
+      "custom/separator#dot-line",
+      "group/notify",],
+
+
+  "modules-right": [
+
+    "group/laptop",
+    "custom/separator#blank",
+    "group/mobo_drawer",
+    "custom/separator#line",
+    "group/audio",
+    "custom/separator#dot-line",
+    "mpris",
+    "custom/separator#blank",
+    "custom/nightlight",
+    "group/status",
+      ],
+
+  },
+    {
+    "include": [
+    "$HOME/.config/waybar/Modules",
+    "$HOME/.config/waybar/ModulesWorkspaces",
+    "$HOME/.config/waybar/ModulesCustom",
+    "$HOME/.config/waybar/ModulesGroups",
+    "$HOME/.config/waybar/UserModules",
+    ],
+      "name": "bottombar",
+      "layer": "top",
+      "position": "bottom",
+      "height": 30,
+      "mode": "dock",
+      "exclusive": true,
+      "spacing": 2,
+      "passthrough": true,
+      "gtk-layer-shell": true,
+      "reload_style_on_change": true,
+      "modules-left": [        "hyprland/window",
+      "custom/cava_mviz", "custom/playerctl"],
+      "modules-center": ["wlr/taskbar"],
+      "modules-right": ["custom/backlight",
+      "backlight/slider",
+      "custom/speaker",
+      "pulseaudio/slider", "custom/updater",
+      ],
+    }
+  ]


### PR DESCRIPTION
Added the configuration for SummitSplit to include 0-JA-0 Top and updated the bottom bar settings.

# Pull Request

## Description

Please read these instructions and remove unnecessary text.

Not much to say, new config.
## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [x] **Other** 
New waybar config

## Checklist

Please put an `x` in the boxes that apply:

- [ ] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

<img width="1920" height="1078" alt="image" src="https://github.com/user-attachments/assets/5859a1a3-dbe1-4d7a-bf20-640f74cd05ca" />

## Additional context

Add any other context about the problem here.
