### PR TITLE
fix: Fix dwindle togglesplit syntax

### DIFF
--- a/config/hypr/configs/Keybinds.conf
+++ b/config/hypr/configs/Keybinds.conf
@@ -96,7 +96,7 @@ bindd = $mainMod, I, add master, layoutmsg, addmaster
 bindd = $mainMod CTRL, Return, swap with master, layoutmsg, swapwithmaster
 
 # Dwindle Layout
-bindd = $mainMod SHIFT, I, toggle split (dwindle), togglesplit
+bindd = $mainMod SHIFT, I, toggle split (dwindle), layoutmsg, togglesplit
 bindd = $mainMod, P, toggle pseudo (dwindle), pseudo,
 
 # Works on either layout (Master or Dwindle)


### PR DESCRIPTION
# Pull Request

## Description

This PR is a simple syntax correction.
Was unable to togglesplit in dwindle, found that the old syntax is used.


## Type of change
- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist
Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Hyprland-Dots wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
